### PR TITLE
release(mjc-claude-skill-tool): v1.1.0

### DIFF
--- a/packages/mjc-claude-skill-tool/.claude-plugin/plugin.json
+++ b/packages/mjc-claude-skill-tool/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-claude-skill-tool",
   "description": "Claude Code のスキル品質改善と環境構成レビューのツール群（skill-creator 連携 + コンテキスト管理・静的チェック / アップデートレビュー）",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "mjcreativelab"
   },


### PR DESCRIPTION
## 概要
mjc-claude-skill-tool v1.1.0 リリース

## 変更内容（前バージョンからの差分）
- `claude-code-update-review` スキルを新規追加（Claude Code バージョンアップ後の環境構成レビュー）
- `plugin.json` の description 更新
- `README.md` に新スキルの説明・使い分け表・使用例を追記

## バージョンバンプ理由
マイナー: 既存パッケージに新スキル（`skills/claude-code-update-review/`）を追加