### PR TITLE
release(mjc-claude-skill-tool): v1.2.0

### DIFF
--- a/packages/mjc-claude-skill-tool/.claude-plugin/plugin.json
+++ b/packages/mjc-claude-skill-tool/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-claude-skill-tool",
   "description": "Claude Code のスキル品質改善と環境構成レビューのツール群（skill-creator 連携 + コンテキスト管理・静的チェック / アップデートレビュー）",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "mjcreativelab"
   },


### PR DESCRIPTION
## 概要
mjc-claude-skill-tool v1.2.0 リリース

## 変更内容（前バージョンからの差分）
- `empirical-prompt-tuning` スキルを追加（新規 subagent 実行でプロンプト・skill を反復チューニング）
- `README.md` に新スキルの説明・使用例を追記

## バージョンバンプ理由
マイナー: 既存パッケージに新スキル（`empirical-prompt-tuning`）が追加されたため、リリースルールに従いマイナーバンプ。