### PR TITLE
release(mjc-git-workflow): v1.1.3

### DIFF
--- a/packages/mjc-git-workflow/.claude-plugin/plugin.json
+++ b/packages/mjc-git-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-git-workflow",
   "description": "Git ワークフローを自動化するプラグイン（smart-issue-resolve, smart-commit, smart-pr, smart-review 等）",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "mjcreativelab"
   },


### PR DESCRIPTION
## 概要
mjc-git-workflow v1.1.3 リリース

## 変更内容（前バージョン 1.1.2 からの差分）
- 7 skill の SKILL.md に empirical tuning 結果を反映（description 明確化、frontmatter 整備、Step の明文化）
- `docs/empirical-tuning/` に 7 skill 分 + README の設計書を追加
- `README.md` に smart-pr の merge 挙動を追記
- smart-git-sync の SKILL.md に `model: claude-sonnet-4-6` を追加（コスト最適化）

## バージョンバンプ理由
パッチ: 既存 skill の指示明確化とドキュメント追加のみ。新規 skill 追加なし、挙動の互換性を維持。