### PR TITLE
release(mjc-claude-skill-tool): v1.2.1

### DIFF
--- a/packages/mjc-claude-skill-tool/.claude-plugin/plugin.json
+++ b/packages/mjc-claude-skill-tool/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-claude-skill-tool",
   "description": "Claude Code のスキル品質改善と環境構成レビューのツール群（skill-creator 連携 + コンテキスト管理・静的チェック / アップデートレビュー）",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "mjcreativelab"
   },


### PR DESCRIPTION
## 概要
mjc-claude-skill-tool v1.2.1 リリース

## 変更内容（前バージョン 1.2.0 からの差分）
- `skills/skill-improver/SKILL.md` の description を具体化（検証項目と empirical-prompt-tuning との棲み分けを明記）
- `skills/empirical-prompt-tuning/SKILL.md` の description を具体化（「指示の曖昧さ」を明示、skill-improver との棲み分けを明記）
- `README.md` に 2 skill の使い分け比較表を追加

## バージョンバンプ理由
パッチ: 既存 skill の description 明確化とドキュメント追加のみ。新規 skill 追加なし、挙動の互換性を維持。