### PR TITLE
release: パッケージリネーム対応パッチリリース (3パッケージ)

### DIFF
--- a/packages/mjc-claude-improver-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-claude-improver-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-claude-improver-tools",
   "description": "Claude Code のスキル品質改善と環境構成レビューのツール群（skill-creator 連携 + コンテキスト管理・静的チェック / アップデートレビュー）",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "mjcreativelab"
   },

--- a/packages/mjc-code-develop-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-code-develop-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-code-develop-tools",
   "description": "コード開発ライフサイクルを支援するスキル群（ソフトウェア設計 / コードレビュー / セキュリティ監査）",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "mjcreativelab"
   },

--- a/packages/mjc-git-workflow-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-git-workflow-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-git-workflow-tools",
   "description": "Git ワークフローを自動化するプラグイン（smart-issue-resolve, smart-commit, smart-pr, smart-review 等）",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": {
     "name": "mjcreativelab"
   },


### PR DESCRIPTION
## 概要

パッケージリネーム（PR #33）に対応したパッチリリース。3パッケージを一括更新。

## 変更内容

| パッケージ | 旧バージョン | 新バージョン |
|---|---|---|
| `mjc-git-workflow-tools` | 1.1.4 | 1.1.5 |
| `mjc-claude-improver-tools` | 1.2.1 | 1.2.2 |
| `mjc-code-develop-tools` | 1.0.0 | 1.0.1 |

## バージョンバンプ理由

パッチ: パッケージリネーム（`mjc-git-workflow` → `mjc-git-workflow-tools`、`mjc-claude-skill-tool` → `mjc-claude-improver-tools`）に伴う plugin.json バージョン更新。コードの機能変更なし。