### PR TITLE
release(mjc-claude-improver-tools): v1.2.3

### DIFF
--- a/packages/mjc-claude-improver-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-claude-improver-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mjc-claude-improver-tools",
   "description": "Claude Code のスキル品質改善と環境構成レビューのツール群（skill-creator 連携 + コンテキスト管理・静的チェック / アップデートレビュー）",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": {
     "name": "mjcreativelab"
   },


### PR DESCRIPTION
## 概要
mjc-claude-improver-tools v1.2.3 リリース

## 変更内容（前バージョンからの差分）
- 各スキル（claude-code-update-review, empirical-prompt-tuning, skill-improver）に README を追加（#37）

## バージョンバンプ理由
パッチ: ドキュメント追加のみ。機能追加・破壊的変更なし。
