### PR TITLE
🔧 chore: rename project to mjcreativelab-agent-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "mjcreativelab-claude-plugins",
+  "name": "mjcreativelab-agent-plugins",
   "owner": {
     "name": "mjcreativelab",
     "url": "https://github.com/mjcreativelab"

--- a/.claude/skills/auto-release/SKILL.md
+++ b/.claude/skills/auto-release/SKILL.md
@@ -27,7 +27,7 @@ description: パッケージのバージョン更新・タグ付け・リリー�
 
 `.codex-plugin/` に存在する単一プラグイン（全 skills を内包）。
 
-- **タグ形式**: `mjcreativelab-claude-plugins@<semver>`（例: `mjcreativelab-claude-plugins@0.2.0`）
+- **タグ形式**: `mjcreativelab-agent-plugins@<semver>`（例: `mjcreativelab-agent-plugins@0.2.0`）
 - **バージョン格納先**: `.codex-plugin/plugin.json` の `version`
 - **判定基準**: 前回タグからの `skills/`（rendered codex 配布）配下の差分
 - **リリース条件**: 前回 codex タグから `skills/` に変更があれば claude package と同じ PR で同時バンプ。差分がなければスキップ
@@ -152,7 +152,7 @@ git tag --list '<package-name>@*' --sort=-v:refname | head -1
 codex plugin の既存タグも合わせて検索する:
 
 ```bash
-git tag --list 'mjcreativelab-claude-plugins@*' --sort=-v:refname | head -1
+git tag --list 'mjcreativelab-agent-plugins@*' --sort=-v:refname | head -1
 ```
 
 - **タグが存在する** → そのバージョンを前回バージョンとして使用
@@ -173,7 +173,7 @@ git diff --name-only <package-name>@<version>..HEAD -- packages/<package-name>/
 前回 codex タグから HEAD までの `skills/` 配下の差分を分析する:
 
 ```bash
-git diff --name-only mjcreativelab-claude-plugins@<version>..HEAD -- skills/
+git diff --name-only mjcreativelab-agent-plugins@<version>..HEAD -- skills/
 ```
 
 **差分が空の場合は codex plugin をリリース対象から除外**する。差分がある場合のみバンプ判定の対象とする。
@@ -282,8 +282,8 @@ git push origin <package-name>@<version>
 codex plugin もリリース対象の場合、同じコミットに codex タグも付ける:
 
 ```bash
-git tag mjcreativelab-claude-plugins@<codex-version>
-git push origin mjcreativelab-claude-plugins@<codex-version>
+git tag mjcreativelab-agent-plugins@<codex-version>
+git push origin mjcreativelab-agent-plugins@<codex-version>
 ```
 
 ### 12. 結果報告
@@ -298,7 +298,7 @@ git push origin mjcreativelab-claude-plugins@<codex-version>
     タグ: <package-name>@<version>
   codex plugin: <skip または以下を表示>
     バージョン: <old-codex-version> → <codex-version>
-    タグ: mjcreativelab-claude-plugins@<codex-version>
+    タグ: mjcreativelab-agent-plugins@<codex-version>
   PR: <pr-url>
 ```
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "mjcreativelab-claude-plugins",
+  "name": "mjcreativelab-agent-plugins",
   "version": "1.0.0",
   "description": "Codex plugin distribution for MJC reusable skills.",
   "skills": "./skills/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,10 +219,10 @@ target 差分の扱い:
 
 ```bash
 # marketplace として登録
-/plugin marketplace add mjcreativelab/mjcreativelab-claude-plugins
+/plugin marketplace add mjcreativelab/mjcreativelab-agent-plugins
 
 # プラグインをインストール
-/plugin install <plugin-name>@mjcreativelab-claude-plugins
+/plugin install <plugin-name>@mjcreativelab-agent-plugins
 ```
 
 ### キャッシュの注意
@@ -346,3 +346,4 @@ Git タグは変更不可 — 旧タグは旧名のまま残る。新リリー�
 
 - `mjc-git-workflow` → `mjc-git-workflow-tools`（旧タグ: `mjc-git-workflow@1.1.4` まで）
 - `mjc-claude-skill-tool` → `mjc-claude-improver-tools`（旧タグ: `mjc-claude-skill-tool@1.2.1` まで）
+- `mjcreativelab-claude-plugins` → `mjcreativelab-agent-plugins`（リポジトリ名・marketplace 名・codex plugin 名を一括リネーム。旧 codex タグ: `mjcreativelab-claude-plugins@1.0.0` まで）

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mjcreativelab-claude-plugins
+# mjcreativelab-agent-plugins
 
 Claude Code と Codex 用のプラグイン集。skills, hooks, rules を monorepo で管理し、`skills-sources/` から各エージェント向けに render して配布する。
 
@@ -14,23 +14,23 @@ Claude Code と Codex 用のプラグイン集。skills, hooks, rules を monore
 
 ```
 # 1. marketplace として登録
-/plugin marketplace add mjcreativelab/mjcreativelab-claude-plugins
+/plugin marketplace add mjcreativelab/mjcreativelab-agent-plugins
 
 # 2. プラグインをインストール
-/plugin install <package-name>@mjcreativelab-claude-plugins
+/plugin install <package-name>@mjcreativelab-agent-plugins
 ```
 
 例:
 
 ```
-/plugin install mjc-git-workflow-tools@mjcreativelab-claude-plugins
-/plugin install mjc-claude-improver-tools@mjcreativelab-claude-plugins
-/plugin install mjc-code-develop-tools@mjcreativelab-claude-plugins
+/plugin install mjc-git-workflow-tools@mjcreativelab-agent-plugins
+/plugin install mjc-claude-improver-tools@mjcreativelab-agent-plugins
+/plugin install mjc-code-develop-tools@mjcreativelab-agent-plugins
 ```
 
 ## Codex でのインストール
 
-このリポジトリ自体が Codex プラグイン（`name: mjcreativelab-claude-plugins`）として機能する。`.codex-plugin/plugin.json` がマニフェスト、ルート直下の [skills/](skills/) が skill 配置先。Codex CLI のプラグイン取り込み機能でリポジトリを指定して導入する。
+このリポジトリ自体が Codex プラグイン（`name: mjcreativelab-agent-plugins`）として機能する。`.codex-plugin/plugin.json` がマニフェスト、ルート直下の [skills/](skills/) が skill 配置先。Codex CLI のプラグイン取り込み機能でリポジトリを指定して導入する。
 
 Codex 側はパッケージ階層を平坦化し、Codex target が有効な skill を `skills/<skill>/` 直下に配置する。Claude 専用 skill は Codex 配布から除外される。
 

--- a/packages/mjc-claude-improver-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-claude-improver-tools/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "mjcreativelab"
   },
-  "repository": "https://github.com/mjcreativelab/mjcreativelab-claude-plugins"
+  "repository": "https://github.com/mjcreativelab/mjcreativelab-agent-plugins"
 }

--- a/packages/mjc-code-develop-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-code-develop-tools/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "mjcreativelab"
   },
-  "repository": "https://github.com/mjcreativelab/mjcreativelab-claude-plugins"
+  "repository": "https://github.com/mjcreativelab/mjcreativelab-agent-plugins"
 }

--- a/packages/mjc-git-workflow-tools/.claude-plugin/plugin.json
+++ b/packages/mjc-git-workflow-tools/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "mjcreativelab"
   },
-  "repository": "https://github.com/mjcreativelab/mjcreativelab-claude-plugins"
+  "repository": "https://github.com/mjcreativelab/mjcreativelab-agent-plugins"
 }

--- a/packages/mjc-git-workflow-tools/README.md
+++ b/packages/mjc-git-workflow-tools/README.md
@@ -99,8 +99,8 @@ PR レビュー元の場合はコメントへの返信も行う。
 
 ```
 # 1. marketplace として登録
-/plugin marketplace add mjcreativelab/mjcreativelab-claude-plugins
+/plugin marketplace add mjcreativelab/mjcreativelab-agent-plugins
 
 # 2. mjc-git-workflow-tools プラグインをインストール
-/plugin install mjc-git-workflow-tools@mjcreativelab-claude-plugins
+/plugin install mjc-git-workflow-tools@mjcreativelab-agent-plugins
 ```


### PR DESCRIPTION
## Summary

リポジトリ・marketplace・codex plugin の名称を `mjcreativelab-claude-plugins` から `mjcreativelab-agent-plugins` に変更。

## 変更内容

- `marketplace.json` / `.codex-plugin/plugin.json` の `name` を更新
- 各 `packages/*/。claude-plugin/plugin.json` の `repository` URL を更新
- `README.md` / `CLAUDE.md` / `packages/mjc-git-workflow-tools/README.md` のインストール手順・記載を更新
- `auto-release` SKILL.md の codex タグ形式を `mjcreativelab-agent-plugins@<semver>` に変更
- `CLAUDE.md` のパッケージ名変更履歴に今回のリネームを追記（旧 codex タグ: `mjcreativelab-claude-plugins@1.0.0` まで）

## 後続作業

このマージ後にリポジトリ自体を `gh repo rename mjcreativelab-agent-plugins` でリネームし、ローカル remote URL を更新する。既存の Git タグ（`mjcreativelab-claude-plugins@1.0.0` 等）は不変。

## Test plan

- [x] `grep -r "mjcreativelab-claude-plugins"` で残存参照なしを確認
- [ ] マージ後 `gh repo rename` 実行
- [ ] ローカル `git remote set-url` で URL 更新確認