### PR TITLE
chore(distribution): npx タグ運用の確定と内部 skill の配布除外

### DIFF
--- a/.claude/skills/auto-release/SKILL.md
+++ b/.claude/skills/auto-release/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: auto-release
 description: パッケージのバージョン更新・タグ付け・リリース PR の作成・マージを一括で行う。ユーザーが「リリースして」「バージョン上げて」「/auto-release」と言ったら起動する。
+metadata:
+  internal: true
 ---
 
 # Auto Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,18 @@ packages/
 
 注意点:
 
-- `.claude/skills/`（プロジェクトローカル。例: `auto-release`）は配布対象外だが、`npx skills` の探索には出る。配布対象を絞る場合は `--skill <name>` の名前指定を使う（`--skill '*'` は内部 skill も含む）。
+- `.claude/skills/`（プロジェクトローカル。例: `auto-release`）は配布対象外。`npx skills` の探索から隠すため frontmatter に `metadata.internal: true` を付ける（`INSTALL_INTERNAL_SKILLS=1` 時のみ可視）。これにより `--skill '*'` でも配布対象の skill のみが入る。
 - 配布先に symlink を作らない。skill 内のサポートファイル参照は `${CLAUDE_SKILL_DIR}` ではなく SKILL.md からの相対パスを基本にすると各エージェントで解決しやすい。
 - 新規 skill・新規 package 追加時に同期スクリプトは不要（`packages/` を直接編集するだけ）。
+
+### タグ運用
+
+2 系統のタグを併用する（互いに別軸）:
+
+- **repo-level `v<X.Y.Z>`**: `npx skills` の pin 用（例: `npx skills add <repo>@v1.0.0 ...`）。移行完了点（npx 配布開始）を `v1.0.0` とし、Claude marketplace を撤去する将来の major 変更を `v2.0.0` に予約する。
+- **per-package `<package>@<semver>`**: Claude marketplace 用。`/auto-release` が `packages/<plugin>/` 差分で判定・発行する。
+
+Git タグは不変。リネーム前の旧タグ（per-package・旧 codex 配布の `mjcreativelab-claude-plugins@1.0.0`）はそのまま残る。
 
 ## プラグイン構造
 

--- a/README.md
+++ b/README.md
@@ -40,20 +40,20 @@ Claude Code / Codex / Cursor / Gemini など各種エージェント用のスキ
 # 利用可能な skill 一覧
 npx skills add mjcreativelab/mjcreativelab-agent-plugins --list
 
-# 推奨: グローバル install（更新は npx skills update で完結）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --skill smart-commit -g
+# 推奨: グローバル install + タグ pin（更新は npx skills update で完結）
+npx skills add mjcreativelab/mjcreativelab-agent-plugins@v1.0.0 --skill smart-commit -g
 
 # エージェント指定（例: Codex）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --skill smart-commit -a codex -g
+npx skills add mjcreativelab/mjcreativelab-agent-plugins@v1.0.0 --skill smart-commit -a codex -g
 
 # 更新確認 / 取り込み（global）
 npx skills check
 npx skills update
 ```
 
-- 推奨は **グローバル install（`-g`）**。プロジェクト install は `npx skills update` の対象外になる場合があるため、更新は再 add で取り込む。
-- バージョン pin 用の repo-level タグ（`v<X.Y.Z>`）発行は整備中（移行計画 Phase 1）。pin する場合は `mjcreativelab/mjcreativelab-agent-plugins@<tag>` の形で付与する。なお claude package の per-package タグ（`<package>@<semver>`）は別軸で継続する。
-- skill は名前で個別指定する（`--skill <name>`）。`--skill '*'` は本リポジトリ運用用の内部 skill（例: `auto-release`）も含むため、配布対象を絞りたい場合は名前指定を推奨。
+- 推奨は **グローバル install（`-g`）+ タグ pin（`@v<X.Y.Z>`）**。プロジェクト install は `npx skills update` の対象外になる場合があるため、更新は再 add で取り込む。
+- **バージョン pin** には repo-level タグ `v<X.Y.Z>` を使う（例: `@v1.0.0`）。タグ無しは HEAD 追従の「お試し」用途。なお Claude Code marketplace 用の per-package タグ（`<package>@<semver>`）は別軸で継続する。
+- skill は名前で個別指定する（`--skill <name>`）。本リポジトリ運用用の内部 skill（例: `auto-release`）は `metadata.internal: true` で npx 配布から除外済みのため、`--skill '*'` でも配布対象の skill のみが入る。
 
 ## ライセンス
 

--- a/docs/migration-npx-skills.md
+++ b/docs/migration-npx-skills.md
@@ -20,6 +20,10 @@ Phase 0 検証（`docs/specs/npx-skills-compatibility-report.md`）の結果を�
 - `auto-release` は claude package 単一バージョニングへ簡素化済み。
 - 以下の Phase 記述のうち「`skill-sources/` 維持」「`packages/<plugin>/skills/` 削除」を前提とする箇所は
   本メモが優先する（Phase 2 の sync 単一化は「skill-sources 全廃」で代替済み）。
+- **タグ運用を確定**: repo-level `v<X.Y.Z>`（npx pin 用・初回 `v1.0.0`）+ per-package `<package>@<semver>`
+  （Claude marketplace 用）の併用。`v2.0.0` は marketplace 撤去（Phase 4）に予約。
+- **内部 skill の npx 除外を確定**: プロジェクトローカルの `auto-release` に `metadata.internal: true` を付与し、
+  `npx skills` の探索対象から除外（`--skill '*'` でも配布対象のみ）。
 
 > ⚠️ **以降（§1〜§9）は実装前の当初ドラフト（2026-05 時点・履歴）**。`skill-sources/` / `/skill-sync` /
 > `tools/sync_skill_sources.py` / ルート `skills/` / `packages/*/skills/` 削除 などに言及する箇所は、


### PR DESCRIPTION
Issue #47 の Phase 1 残り（タグ運用）と配布の細部（内部 skill 除外）に対応する。

## 変更

- **内部 skill の npx 除外**: `.claude/skills/auto-release/SKILL.md` に `metadata.internal: true` を付与。`npx skills` の探索から除外され、`--skill '*'` でも配布対象 skill のみが入る（`INSTALL_INTERNAL_SKILLS=1` 時のみ可視）。
- **タグ運用の確定**:
  - repo-level `v<X.Y.Z>` … `npx skills` の pin 用（例: `@v1.0.0`）。移行完了点を `v1.0.0`、marketplace 撤去（Phase 4）を `v2.0.0` に予約。
  - per-package `<package>@<semver>` … Claude marketplace 用に継続（`/auto-release`）。
- README / CLAUDE.md / `docs/migration-npx-skills.md` に上記を反映。README の npx 例を `@v1.0.0` pin に更新。

## 検証

- `npx skills add ./ --list` で `auto-release` が候補から消えることを実機確認（配布対象 15 skill のみ）。
- `claude plugin validate .` 通過（marketplace は不変）。

## マージ後の作業

- [ ] 本 PR マージ後に **`v1.0.0` タグ**をマージコミットへ発行（README の `@v1.0.0` 例が解決するように）。

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)