### PR TITLE
docs: --skill '*' は内部 skill を除外しない点を訂正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ packages/
 
 注意点:
 
-- `.claude/skills/`（プロジェクトローカル。例: `auto-release`）は配布対象外。`npx skills` の探索から隠すため frontmatter に `metadata.internal: true` を付ける（`INSTALL_INTERNAL_SKILLS=1` 時のみ可視）。これにより `--skill '*'` でも配布対象の skill のみが入る。
+- `.claude/skills/`（プロジェクトローカル。例: `auto-release`）は配布対象外。frontmatter に `metadata.internal: true` を付けると `npx skills ... --list` の表示からは隠れる。ただし**このバージョンの `npx skills` は `--skill '*'`（wildcard install）から internal を除外しない**ため、`--skill '*'` には含まれてしまう。配布対象だけをクリーンに入れるには `--skill <name>` を名前指定する。
 - 配布先に symlink を作らない。skill 内のサポートファイル参照は `${CLAUDE_SKILL_DIR}` ではなく SKILL.md からの相対パスを基本にすると各エージェントで解決しやすい。
 - 新規 skill・新規 package 追加時に同期スクリプトは不要（`packages/` を直接編集するだけ）。
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ npx skills update
 
 - 推奨は **グローバル install（`-g`）+ タグ pin（`@v<X.Y.Z>`）**。プロジェクト install は `npx skills update` の対象外になる場合があるため、更新は再 add で取り込む。
 - **バージョン pin** には repo-level タグ `v<X.Y.Z>` を使う（例: `@v1.0.0`）。タグ無しは HEAD 追従の「お試し」用途。なお Claude Code marketplace 用の per-package タグ（`<package>@<semver>`）は別軸で継続する。
-- skill は名前で個別指定する（`--skill <name>`）。本リポジトリ運用用の内部 skill（例: `auto-release`）は `metadata.internal: true` で npx 配布から除外済みのため、`--skill '*'` でも配布対象の skill のみが入る。
+- skill は名前で個別指定する（`--skill <name>`）。全 skill を一括で入れるなら `--skill '*'`（zsh はクォート必須）。
+- 内部 skill `auto-release` は `metadata.internal: true` で `npx skills ... --list` の表示からは隠れるが、**`--skill '*'` では install される**（このバージョンの `npx skills` は wildcard から internal を除外しない）。`auto-release` は本リポジトリ専用のため他環境では不要。配布対象だけをクリーンに入れたい場合は `--skill <name>` を列挙する。
 
 ## ライセンス
 

--- a/docs/migration-npx-skills.md
+++ b/docs/migration-npx-skills.md
@@ -22,8 +22,9 @@ Phase 0 検証（`docs/specs/npx-skills-compatibility-report.md`）の結果を�
   本メモが優先する（Phase 2 の sync 単一化は「skill-sources 全廃」で代替済み）。
 - **タグ運用を確定**: repo-level `v<X.Y.Z>`（npx pin 用・初回 `v1.0.0`）+ per-package `<package>@<semver>`
   （Claude marketplace 用）の併用。`v2.0.0` は marketplace 撤去（Phase 4）に予約。
-- **内部 skill の npx 除外を確定**: プロジェクトローカルの `auto-release` に `metadata.internal: true` を付与し、
-  `npx skills` の探索対象から除外（`--skill '*'` でも配布対象のみ）。
+- **内部 skill の扱い**: `auto-release` に `metadata.internal: true` を付与（`npx skills ... --list` の表示から隠す）。
+  ただし**このバージョンの npx は `--skill '*'` から internal を除外しない**ため、wildcard install には含まれる。
+  クリーンな配布は `--skill <name>` の名前指定で行う（要追跡: npx 側の wildcard 除外手段 / auto-release の配置）。
 
 > ⚠️ **以降（§1〜§9）は実装前の当初ドラフト（2026-05 時点・履歴）**。`skill-sources/` / `/skill-sync` /
 > `tools/sync_skill_sources.py` / ルート `skills/` / `packages/*/skills/` 削除 などに言及する箇所は、


### PR DESCRIPTION
PR #48 で「`metadata.internal: true` により `--skill '*'` でも配布対象 skill のみが入る」と記載したが、検証の結果これは**誤り**だった。

## 検証で判明した実態
- `metadata.internal: true`（boolean / string どちらも）は `npx skills ... --list` の**表示からは隠す**。
- しかし `--skill '*'`（wildcard install）と明示 `--skill auto-release` では**install される**（このバージョンの npx は wildcard から internal を除外しない）。

## 修正
- README / CLAUDE.md / `docs/migration-npx-skills.md` の該当記述を実態へ訂正。
- 全 skill 一括は `--skill '*'`（auto-release も含む）、配布対象だけクリーンに入れるなら `--skill <name>` 名前指定、と明記。

## 補足
- 変更は**リポジトリのドキュメントのみ**（配布される skill 本体は不変）。npx 利用者が install する内容に影響はない。
- `--skill '*'` から internal を除外する確実な手段は未確立（Issue #47 で追跡）。

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)