### PR TITLE
docs: npx skills の ref pin 構文を `#ref` に訂正（`@` は skill フィルタ）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,9 @@ head -5 skills/<skill-name>/SKILL.md
 
 # リリース（repo-level v<X.Y.Z> タグの発行 + GitHub Release）
 /auto-release
+
+# git pull が "unable to update local ref" で失敗した場合の復旧（マージ直後に発生することがある）
+git update-ref refs/remotes/origin/main <merge-sha> && git reset --hard <merge-sha>
 ```
 
 ## リポジトリ構造
@@ -109,7 +112,7 @@ docs/                            # 設計・移行ドキュメント（migration
 
 `skills/<skill>/` が skill の唯一の正本（generated な中間物・render 工程は無い）。配布は `npx skills`（[vercel-labs/skills](https://github.com/vercel-labs/skills)・git tree-SHA ベース）:
 
-- `npx skills add mjcreativelab/mjcreativelab-agent-plugins@v<X.Y.Z> --skill <name> -g` で各エージェントへ install。skill は `.agents/skills/<skill>/` に配置され Claude Code / Codex / Cursor / Gemini CLI / GitHub Copilot 等へ展開される。
+- `npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v<X.Y.Z>' --skill <name> -g` で各エージェントへ install。skill は `.agents/skills/<skill>/` に配置され Claude Code / Codex / Cursor / Gemini CLI / GitHub Copilot 等へ展開される。
 - frontmatter は逐語コピーされる（`allowed-tools` 等は標準仕様、`argument-hint` / `disable-model-invocation` は Claude 拡張で他エージェントは無視）。
 
 注意点:
@@ -118,11 +121,13 @@ docs/                            # 設計・移行ドキュメント（migration
   - **`.claude/skills/` には置かない**: npx のリモート探索は浅い標準ルートを 1 つ見つけると深い探索をしない。`.claude/skills/` に skill があると `skills/` をシャドウし、配布 skill が発見されなくなる（v2.0.0→2.0.1 でこれを踏んだ）。
   - ローカルでこのリポジトリ自身に `/auto-release` を使う場合は `npx skills add ./ --skill auto-release -g`（internal なので明示指定で導入）で global install して呼ぶ。
 - 配布先に symlink を作らない。skill 内のサポートファイル参照は `${CLAUDE_SKILL_DIR}` ではなく SKILL.md からの相対パスを基本にすると各エージェントで解決しやすい。
+- npx のデフォルト探索は浅い（全階層走査は `--full-depth`）。
+- **`@` は ref ではなく skill フィルタ**: `owner/repo@X` の `@X` は `--skill X` 相当（CLI v1.5.9 の source-parser で確認）。バージョン pin は fragment 構文 **`owner/repo#v<X.Y.Z>`**（zsh ではソース全体を引用符で囲む。`#ref@skill` の複合も可）。`#ref` は探索・install に効き、lock（skills-lock.json）に `ref` が記録され `npx skills update` も pin に従う。ただし blob fast path（skills.sh download API）が ref を渡さない既知問題があり（[vercel-labs/skills#1123](https://github.com/vercel-labs/skills/pull/1123) で修正中）、ref の中身の権威確認は `git ls-tree -r origin/<ref> --name-only` で行う。
 - 新規 skill 追加時に同期スクリプト・マニフェストは不要（`skills/<skill>/` を直接追加するだけ）。
 
 ### タグ運用
 
-- **repo-level `v<X.Y.Z>`**（SemVer）: `npx skills` の pin 用（例: `npx skills add <repo>@v2.0.0 ...`）。`/auto-release` が `skills/` 差分で判定・発行する。バージョンは git タグのみ（バージョンファイル・plugin.json なし）。
+- **repo-level `v<X.Y.Z>`**（SemVer）: `npx skills` の pin 用（例: `npx skills add '<repo>#v2.0.1' ...`。`@` ではなく `#`）。`/auto-release` が `skills/` 差分で判定・発行する。バージョンは git タグのみ（バージョンファイル・plugin.json なし）。
 - 旧タグ（per-package `<package>@<semver>`・旧 codex `mjcreativelab-claude-plugins@1.0.0`）は不変で残る（履歴）。これらは廃止済みの旧配布経路のもの。
 
 ## スキルファイル形式

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ head -5 skills/<skill-name>/SKILL.md
 /auto-release
 
 # git pull が "unable to update local ref" で失敗した場合の復旧（マージ直後に発生することがある）
+# 注意: reset --hard は未コミット変更を破棄する。実行前に git status --short で clean を確認すること
 git update-ref refs/remotes/origin/main <merge-sha> && git reset --hard <merge-sha>
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,29 +21,30 @@ skill 単位にクロスツール install できる。skill は `.agents/skills/
 # 利用可能な skill 一覧
 npx skills add mjcreativelab/mjcreativelab-agent-plugins --list
 
-# 推奨: グローバル install + タグ pin（更新は npx skills update で完結）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.1 --skill smart-commit -g
+# 推奨: グローバル install + タグ pin（`#v<X.Y.Z>`。zsh ではソースを引用符で囲む）
+npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1' --skill smart-commit -g
 
 # エージェント指定（例: Codex）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.1 --skill smart-commit -a codex -g
+npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1' --skill smart-commit -a codex -g
 
 # 全 skill を一括（zsh は '*' をクォート）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.1 --skill '*' -g
+npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1' --skill '*' -g
 
 # 更新確認 / 取り込み（global）
 npx skills check
 npx skills update
 ```
 
-- 推奨は **グローバル install（`-g`）+ タグ pin（`@v<X.Y.Z>`）**。プロジェクト install は `npx skills update` の対象外になる場合があるため、更新は再 add で取り込む。
-- **バージョン pin** には repo-level タグ `v<X.Y.Z>` を使う（例: `@v2.0.1`）。タグ無しは HEAD 追従の「お試し」用途。
+- 推奨は **グローバル install（`-g`）+ タグ pin（`#v<X.Y.Z>`）**。プロジェクト install は `npx skills update` の対象外になる場合があるため、更新は再 add で取り込む。
+- **バージョン pin** は fragment 構文 `#v<X.Y.Z>` で指定する（例: `'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1'`）。**`@<名前>` は ref ではなく skill フィルタ**（`owner/repo@smart-commit` = `--skill smart-commit` 相当）。タグ無しは default branch 追従の「お試し」用途。
+- pin した install は lock に ref が記録され、`npx skills update` も pin に従う（タグ pin は据え置き）。新しいタグへ上げるときは `#v<新タグ>` で再 add する。
 - 内部 skill `auto-release` は `metadata.internal: true` で `npx skills ... --list` の表示からは隠れるが、**`--skill '*'` では install される**（このバージョンの `npx skills` は wildcard から internal を除外しない）。`auto-release` は本リポジトリ専用のため他環境では不要。配布対象だけをクリーンに入れたい場合は `--skill <name>` を列挙する。
 
 ### 旧 marketplace からの移行
 
 旧 `/plugin install` は**パッケージ単位**、新 `npx skills` は**skill 単位**。旧パッケージに含まれていた skill を `--skill` で指定し直す:
 
-| 旧（廃止） | 新（`npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.1 ... -g`） |
+| 旧（廃止） | 新（`npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1' ... -g`） |
 |---|---|
 | `/plugin install mjc-git-workflow-tools@…` | `--skill smart-commit --skill smart-pr --skill smart-git-sync --skill smart-issue-resolve --skill smart-issue-plan --skill smart-review --skill smart-review-apply` |
 | `/plugin install mjc-claude-improver-tools@…` | `--skill skill-improver --skill empirical-prompt-tuning --skill claude-code-update-review` |

--- a/docs/migration-npx-skills.md
+++ b/docs/migration-npx-skills.md
@@ -34,9 +34,10 @@ Phase 0 検証（`docs/specs/npx-skills-compatibility-report.md`）の結果を�
   `--full-depth` 無しでは発見されず（clean probe で default=1 / `--full-depth`=16 を確認）。marketplace.json が
   暗黙の探索ポインタを兼ねていたため撤去で露呈した。配布 skill を npx 標準の浅い `skills/<skill>/` へ移設し、
   `packages/<group>/` は README（グループ説明）のみに。`/auto-release` のバンプ判定基準も `skills/` 差分へ更新。
-  **注意（要クリーン環境検証）**: 内部 skill `auto-release`（`.claude/skills/`）が `skills/` 探索を妨げないかは、
+  ~~**注意（要クリーン環境検証）**: 内部 skill `auto-release`（`.claude/skills/`）が `skills/` 探索を妨げないかは、
   本セッションの npx clone キャッシュ汚染により未検証。別マシン/CI 等の clean 環境で `@v2.0.1 --list` が
-  全 skill を返すことを確認すること。
+  全 skill を返すことを確認すること。~~ → **検証済み・解消（2026-06-02）**: `'#v2.0.1' --list` が
+  15 配布 skill を返すことを確認（次項参照。`@v2.0.1` という当時の検証コマンド自体が誤構文だった）。
 - **`@<ref>` 問題の真因判明（2026-06-02・CLI v1.5.9 ソース照合 + 実証）**: `owner/repo@X` の `@X` は
   **ref ではなく skill フィルタ**（`--skill X` 相当）。本メモおよび README の `@v<X.Y.Z>` pin 例は version pin
   として機能していなかった（探索は常に default branch）。「キャッシュ汚染」「CLI バージョンの揺れ」という

--- a/docs/migration-npx-skills.md
+++ b/docs/migration-npx-skills.md
@@ -37,6 +37,13 @@ Phase 0 検証（`docs/specs/npx-skills-compatibility-report.md`）の結果を�
   **注意（要クリーン環境検証）**: 内部 skill `auto-release`（`.claude/skills/`）が `skills/` 探索を妨げないかは、
   本セッションの npx clone キャッシュ汚染により未検証。別マシン/CI 等の clean 環境で `@v2.0.1 --list` が
   全 skill を返すことを確認すること。
+- **`@<ref>` 問題の真因判明（2026-06-02・CLI v1.5.9 ソース照合 + 実証）**: `owner/repo@X` の `@X` は
+  **ref ではなく skill フィルタ**（`--skill X` 相当）。本メモおよび README の `@v<X.Y.Z>` pin 例は version pin
+  として機能していなかった（探索は常に default branch）。「キャッシュ汚染」「CLI バージョンの揺れ」という
+  当時の推定は誤り。正しい ref pin は fragment 構文 **`owner/repo#v<X.Y.Z>`**（`#ref@skill` 複合可）。
+  `'#v2.0.1' --list` が 15 skill を返すこと、probe ブランチで `#ref` install が ref の中身を届けることを実証済み。
+  既知の上流問題: blob fast path（skills.sh download API）は ref を渡さない
+  （[vercel-labs/skills#1123](https://github.com/vercel-labs/skills/pull/1123) で修正中）。詳細は Issue #47 のコメント参照。
 
 > ⚠️ **以降（§1〜§9）は実装前の当初ドラフト（2026-05 時点・履歴）**。`skill-sources/` / `/skill-sync` /
 > `tools/sync_skill_sources.py` / ルート `skills/` / `packages/*/skills/` 削除 などに言及する箇所は、

--- a/packages/mjc-git-workflow-tools/README.md
+++ b/packages/mjc-git-workflow-tools/README.md
@@ -103,7 +103,7 @@ PR レビュー元の場合はコメントへの返信も行う。
 # 一覧
 npx skills add mjcreativelab/mjcreativelab-agent-plugins --list
 
-# 個別 install（推奨: グローバル + タグ pin）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.1 --skill smart-commit -g
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.1 --skill smart-pr -g
+# 個別 install（推奨: グローバル + タグ pin。pin は `#v<X.Y.Z>`、`@` は skill フィルタ）
+npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1' --skill smart-commit -g
+npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v2.0.1' --skill smart-pr -g
 ```

--- a/skills/auto-release/SKILL.md
+++ b/skills/auto-release/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 `npx skills` 配布のために repo-level の `v<X.Y.Z>` タグを発行する。skill 本体は
 `skills/<skill>/` が正本で、配布は `npx skills`（git tree-SHA ベース）。
-利用者は `npx skills add <repo>@v<X.Y.Z> ...` でバージョンを pin できる。
+利用者は `npx skills add '<repo>#v<X.Y.Z>' ...` でバージョンを pin できる（`#` が ref。`@` は skill フィルタ）。
 
 > Claude marketplace（`.claude-plugin/marketplace.json` / per-package `plugin.json` /
 > per-package タグ `<package>@<semver>`）は v2.0.0 で撤去済み。本スキルは repo-level タグ専用。
@@ -112,7 +112,7 @@ gh release create v<X.Y.Z> --title "v<X.Y.Z>" --notes "<差分要約・移行注
   バージョン: v<old> → v<X.Y.Z>
   タグ: v<X.Y.Z>
   Release: <release-url>
-  pin 例: npx skills add mjcreativelab/mjcreativelab-agent-plugins@v<X.Y.Z> --skill <name> -g
+  pin 例: npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v<X.Y.Z>' --skill <name> -g
 ```
 
 ## 注意事項


### PR DESCRIPTION
## 概要

Issue #47 残項目①（`@<ref>` 挙動の追跡と README pin 案内の精緻化）の対応。

vercel-labs/skills CLI **v1.5.9（最新）のソースコード照合**と**実証実験**により、`@<ref>` 問題の真因が判明:

- **`owner/repo@X` の `@X` は ref ではなく skill フィルタ**（`--skill X` 相当）。`src/source-parser.ts` の `atSkillMatch` で確認
- 従来ドキュメントの `@v<X.Y.Z>` pin 例は **version pin として機能していなかった**（探索は常に default branch）。過去に観測した「@ref が無視される」現象の真因（キャッシュ汚染説・CLI バージョン揺れ説は誤りだった）
- 正しい ref pin は **fragment 構文 `owner/repo#v<X.Y.Z>`**（`#ref@skill` 複合可、`/tree/<ref>` URL 形式も可）

## 実証内容

| 検証 | 結果 |
|---|---|
| `'#v2.0.1' --list` | 15 配布 skill を正しく列挙 |
| `'#v2.0.0' --list` | 同タグのツリーから列挙（ref が探索に効いている） |
| probe ブランチにマーカー入り SKILL.md を置いて `#<branch>` install | **マーカー入り（ref の中身）が届いた**（clone パス経由） |
| `skills-lock.json` | `ref` フィールドが記録され、`npx skills update` も pin に従う（update.ts で確認） |
| internal 機構 | `--skill` 明示（`'*'` 含む）または `INSTALL_INTERNAL_SKILLS=1` で internal を含む（skills.ts / add.ts で確認）→ 既存 README 記述をソースで裏付け |

## 既知の上流問題（注記として記載）

blob fast path（skills.sh download API `/api/download/owner/repo/slug`）は **ref を渡さない**ため、`#ref` 指定でも install 実体が default branch の snapshot になり得る。修正 PR が open: [vercel-labs/skills#1123](https://github.com/vercel-labs/skills/pull/1123)。本リポジトリは skills.sh にインデックス済みのため潜在的に影響あり（今回の実測では clone フォールバックで ref が守られた）。

## 変更内容

- README.md / CLAUDE.md / packages/mjc-git-workflow-tools/README.md / skills/auto-release/SKILL.md: pin 例を `'owner/repo#v<X.Y.Z>'` に統一（zsh 向けに引用符付き）
- README.md: `@<名前>` = skill フィルタの注意、lock の ref 記録と `update` の pin 追従、タグ更新は再 add を追記
- docs/migration-npx-skills.md: 真因判明の訂正を追記（当時の推定の誤りを明記）
- CLAUDE.md: 承認済み session learnings 2 件も同梱（npx 検証作法の精緻化 / `git pull` "unable to update local ref" 復旧手順）

> 配布 skill の変更は internal の `auto-release` のみ → バージョンバンプ不要（docs リリース）

refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)