### PR TITLE
chore: リポジトリ名変更に伴うドキュメント参照パスの更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ docs/                            # 設計・移行ドキュメント（migration
 
 `skills/<skill>/` が skill の唯一の正本（generated な中間物・render 工程は無い）。配布は `npx skills`（[vercel-labs/skills](https://github.com/vercel-labs/skills)・git tree-SHA ベース）:
 
-- `npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v<X.Y.Z>' --skill <name> -g` で各エージェントへ install。skill は `.agents/skills/<skill>/` に配置され Claude Code / Codex / Cursor / Gemini CLI / GitHub Copilot 等へ展開される。
+- `npx skills add 'mjcreativelab/mjcreativelab-agent-prompts#v<X.Y.Z>' --skill <name> -g` で各エージェントへ install。skill は `.agents/skills/<skill>/` に配置され Claude Code / Codex / Cursor / Gemini CLI / GitHub Copilot 等へ展開される。
 - frontmatter は逐語コピーされる（`allowed-tools` 等は標準仕様、`argument-hint` / `disable-model-invocation` は Claude 拡張で他エージェントは無視）。
 
 注意点:
@@ -240,6 +240,7 @@ Git タグは変更不可 — 旧タグは旧名のまま残る。グループ�
 - `mjc-git-workflow` → `mjc-git-workflow-tools`（旧タグ: `mjc-git-workflow@1.1.4` まで）
 - `mjc-claude-skill-tool` → `mjc-claude-improver-tools`（旧タグ: `mjc-claude-skill-tool@1.2.1` まで）
 - `mjcreativelab-claude-plugins` → `mjcreativelab-agent-plugins`（リポジトリ名・旧 marketplace 名・旧 codex plugin 名を一括リネーム。旧 codex タグ: `mjcreativelab-claude-plugins@1.0.0` まで）
+- `mjcreativelab-agent-plugins` → `mjcreativelab-agent-prompts`（リポジトリ名変更。npx 参照パスを更新）
 
 ### 配布経路の変更履歴
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mjcreativelab-agent-plugins
+# mjcreativelab-agent-prompts
 
 Claude Code / Codex / Cursor / Gemini など各種エージェント用のスキル集。`skills/<skill>/` を正本として monorepo で管理し、[vercel-labs/skills](https://github.com/vercel-labs/skills) の **`npx skills`** で配布する（クロスツール・単一経路）。
 
@@ -24,19 +24,19 @@ skill 単位にクロスツール install できる。skill は `.agents/skills/
 
 ```bash
 # 利用可能な skill 一覧
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --list
+npx skills add mjcreativelab/mjcreativelab-agent-prompts --list
 
 # 推奨: グローバル install（最新を追従）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --skill smart-commit -g
+npx skills add mjcreativelab/mjcreativelab-agent-prompts --skill smart-commit -g
 
 # エージェント指定（例: Codex）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --skill smart-commit -a codex -g
+npx skills add mjcreativelab/mjcreativelab-agent-prompts --skill smart-commit -a codex -g
 
 # 全 skill を一括（zsh は '*' をクォート）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --skill '*' -g
+npx skills add mjcreativelab/mjcreativelab-agent-prompts --skill '*' -g
 
 # 特定バージョンに固定したい場合は末尾に #v<X.Y.Z> を付ける（zsh はソースを引用符で囲む）
-npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v<X.Y.Z>' --skill smart-commit -g
+npx skills add 'mjcreativelab/mjcreativelab-agent-prompts#v<X.Y.Z>' --skill smart-commit -g
 
 # 更新確認 / 取り込み（global）
 npx skills check
@@ -44,7 +44,7 @@ npx skills update
 ```
 
 - 推奨は **グローバル install（`-g`）**。プロジェクト install は `npx skills update` の対象外になる場合があるため、更新は再 add で取り込む。
-- **バージョンを固定したい場合**は fragment 構文 `#v<X.Y.Z>` でタグ pin する（例: `'mjcreativelab/mjcreativelab-agent-plugins#v<X.Y.Z>'`）。タグ無しは default branch（最新）追従。**`@<名前>` は ref ではなく skill フィルタ**（`owner/repo@smart-commit` = `--skill smart-commit` 相当）。
+- **バージョンを固定したい場合**は fragment 構文 `#v<X.Y.Z>` でタグ pin する（例: `'mjcreativelab/mjcreativelab-agent-prompts#v<X.Y.Z>'`）。タグ無しは default branch（最新）追従。**`@<名前>` は ref ではなく skill フィルタ**（`owner/repo@smart-commit` = `--skill smart-commit` 相当）。
 - pin した install は lock に ref が記録され、`npx skills update` も pin に従う（タグ pin は据え置き）。新しいタグへ上げるときは `#v<新タグ>` で再 add する。
 - 内部 skill `auto-release`（本リポジトリ専用のリリース用）は `internal/` 配下にあり配布対象外（リモート探索・`--skill '*'` のいずれにも含まれない）。
 
@@ -52,7 +52,7 @@ npx skills update
 
 旧 `/plugin install` は**パッケージ単位**、新 `npx skills` は**skill 単位**。旧パッケージに含まれていた skill を `--skill` で指定し直す:
 
-| 旧（廃止） | 新（`npx skills add mjcreativelab/mjcreativelab-agent-plugins ... -g`） |
+| 旧（廃止） | 新（`npx skills add mjcreativelab/mjcreativelab-agent-prompts ... -g`） |
 |---|---|
 | `/plugin install mjc-git-workflow-tools@…` | `--skill smart-commit --skill smart-pr --skill smart-git-sync --skill smart-issue-resolve --skill smart-issue-plan --skill smart-review --skill smart-review-apply` |
 | `/plugin install mjc-claude-improver-tools@…` | `--skill skill-improver --skill empirical-prompt-tuning --skill claude-code-update-review` |

--- a/docs/migration-npx-skills.md
+++ b/docs/migration-npx-skills.md
@@ -83,7 +83,7 @@ Phase 0 検証（`docs/specs/npx-skills-compatibility-report.md`）の結果を�
 
 ### 1.3 目的
 
-- 配布経路を `npx skills add mjcreativelab/mjcreativelab-agent-plugins` 1 つに集約
+- 配布経路を `npx skills add mjcreativelab/mjcreativelab-agent-prompts` 1 つに集約
 - frontmatter は Claude フル仕様で統一（`argument-hint` / `allowed-tools` / `disable-model-invocation` を保持）
 - skill 著者のフロー（`skill-sources/` を編集 → `/skill-sync`）は変更しない
 
@@ -141,17 +141,17 @@ Phase 0 検証（`docs/specs/npx-skills-compatibility-report.md`）の結果を�
 
 ```bash
 # 利用可能な skill 一覧
-npx skills add mjcreativelab/mjcreativelab-agent-plugins --list
+npx skills add mjcreativelab/mjcreativelab-agent-prompts --list
 
 # ★推奨: グローバルに tag 固定でインストール（更新は `npx skills update` で完結）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.0 --skill smart-commit -g
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.0 --skill '*' -g
+npx skills add mjcreativelab/mjcreativelab-agent-prompts@v2.0.0 --skill smart-commit -g
+npx skills add mjcreativelab/mjcreativelab-agent-prompts@v2.0.0 --skill '*' -g
 
 # プロジェクト install（更新時は再 add が必要）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.0 --skill smart-commit
+npx skills add mjcreativelab/mjcreativelab-agent-prompts@v2.0.0 --skill smart-commit
 
 # Codex / Cursor / Gemini 向け
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.0.0 --skill smart-commit -a codex -g
+npx skills add mjcreativelab/mjcreativelab-agent-prompts@v2.0.0 --skill smart-commit -a codex -g
 
 # 更新確認 / 取り込み（global のみ）
 npx skills check
@@ -159,7 +159,7 @@ npx skills update            # 全 skill を最新タグへ
 npx skills update smart-commit
 
 # プロジェクト install の更新は再 add（lockfile に乗らないため）
-npx skills add mjcreativelab/mjcreativelab-agent-plugins@v2.1.0 --skill '*'
+npx skills add mjcreativelab/mjcreativelab-agent-prompts@v2.1.0 --skill '*'
 ```
 
 ### 3.3 バージョニングとアップデート方式
@@ -188,7 +188,7 @@ marketplace の `/plugin update` とは挙動が異なるため、利用者向�
 
 #### 推奨運用（README に明記する内容）
 
-1. **常用 skill はグローバル install を推奨**: `npx skills add mjcreativelab/mjcreativelab-agent-plugins@<tag> --skill <name> -g`
+1. **常用 skill はグローバル install を推奨**: `npx skills add mjcreativelab/mjcreativelab-agent-prompts@<tag> --skill <name> -g`
    - 更新は `npx skills update` で完結
    - 複数プロジェクトで使い回せる
 2. **プロジェクト固有 skill のみプロジェクト install**: `npx skills add ... --skill <name>`（`-g` なし）

--- a/internal/auto-release/SKILL.md
+++ b/internal/auto-release/SKILL.md
@@ -115,7 +115,7 @@ gh release create v<X.Y.Z> --title "v<X.Y.Z>" --notes "<差分要約・移行注
   バージョン: v<old> → v<X.Y.Z>
   タグ: v<X.Y.Z>
   Release: <release-url>
-  pin 例: npx skills add 'mjcreativelab/mjcreativelab-agent-plugins#v<X.Y.Z>' --skill <name> -g
+  pin 例: npx skills add 'mjcreativelab/mjcreativelab-agent-prompts#v<X.Y.Z>' --skill <name> -g
 ```
 
 ## 注意事項


### PR DESCRIPTION
## 概要

リポジトリを `mjcreativelab-agent-plugins` から `mjcreativelab-agent-prompts` にリネームしたことに伴い、各ドキュメント内の npx インストールコマンド・参照パスを新しいリポジトリ名に更新する。

なお、以下は歴史的記録として意図的に旧名のまま残している：
- `README.md` の旧 marketplace 廃止注記（`@mjcreativelab-agent-plugins` 形式の旧パス）
- `CLAUDE.md` の変更履歴セクション（`mjcreativelab-claude-plugins` → `mjcreativelab-agent-plugins` の記録）

## 変更内容

- `README.md`：タイトルおよび `npx skills add` コマンド例の参照先を更新（6 箇所）
- `CLAUDE.md`：npx コマンド例を更新、変更履歴に今回のリネームを追記
- `internal/auto-release/SKILL.md`：リリース完了時の pin 例を更新
- `docs/migration-npx-skills.md`：npx コマンド例を更新（6 箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)