### PR TITLE
docs: ファイルパスのユーザー名表記禁止ルールを CLAUDE.md に追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Claude Code / Codex / Cursor / Gemini など各種エージェント用のスキ
 
 > 上記規則は `smart-commit` / `smart-issue-plan` / `smart-issue-resolve` / `smart-pr` の各 SKILL.md にも内蔵されている（`npx skills` 経由でインストールされた利用者がプロジェクト外ファイルを参照できないため）。本リポジトリで作業する際は CLAUDE.md（本セクション）が一次情報源。
 
+## 記述ルール
+
+- ファイルパスにユーザー名を含めない。ホームディレクトリは `/Users/<name>/` ではなく `~/` で表記する（SKILL.md・コメント・ドキュメント・コミットメッセージ・PR 本文のいずれも同様）
+
 ## よく使うコマンド
 
 ```bash


### PR DESCRIPTION
## 概要

`chore/rename-repo-references-20260610` ブランチにのみ存在し、main に未マージだったコミット `5f03648` を単独で PR 化します。

## 背景

同ブランチの他コミットは squash マージ済み（リポジトリ名変更 = #61、dotfiles 管理・pull/push skills = #62）ですが、このコミット（CLAUDE.md への「記述ルール」4 行追加）は PR 化されておらず、main のどこにも存在しませんでした。ブランチ整理にあたり内容を失わないよう、単独 PR として復旧します。

## 変更内容

CLAUDE.md に「記述ルール」セクションを追加:

- ファイルパスにユーザー名を含めない。ホームディレクトリは `~/` で表記する（SKILL.md・コメント・ドキュメント・コミットメッセージ・PR 本文のいずれも同様）

元コミット `5f03648` を cherry-pick（原作者・メッセージを保持）。

## 後続

マージ後、`chore/rename-repo-references-20260610` はローカル・リモートとも削除する（全コミットが main に反映されるため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
