### PR TITLE
feat(memory-dream): claude 系レビューループ（--claude-review-loop / -cldrl）を追加

### DIFF
--- a/docs/implementation-notes/2026-07-07-memory-dream-claude-review-loop.md
+++ b/docs/implementation-notes/2026-07-07-memory-dream-claude-review-loop.md
@@ -1,0 +1,30 @@
+# memory-dream への --claude-review-loop（-cldrl）追加
+
+日付: 2026-07-07（JST） / ブランチ: `feature/memory-dream-claude-review-loop`
+
+smart-issue-plan の `--claude-review-loop` と同様の claude 系レビューループを memory-dream に追加した。依頼: 「memory-dream スキルに、smart-issue-plan スキルと同じように --claude-review-loop（-cldrl）オプションを実装して」。
+
+## 仕様に明記されていなかったため判断した事項
+
+1. **standard のみ追加（敵対的 `-cldarl` は追加しない）** — 依頼が `-cldrl` のみだったため。memory-dream には codex 系も standard しかなく（敵対的モード自体が存在しない）、系統追加のみでモード体系は変えないのが最小実装
+2. **採用判定・修正 commit はオーケストレーター（レビュイー）のまま** — smart-issue-plan の claude 系は plan-editor エージェントが `plan.md` を編集するが、memory-dream の修正は「記憶階層リポジトリへの commit」であり、既存 codex ループの不変則（「採用 / 不採用の判定は、レビュイーである Claude が行う」）をそのまま維持した。隔離するのはレビュワーのみ
+3. **雛形は 1 起動 = 1 ラウンド**（`md-dream-review`・レビュワー 1 体） — 修正がラウンド間にオーケストレーター側で発生するため、smart-issue-plan のような「1 Workflow = 3 ラウンド 1 セット」構造は取れない（Workflow 内から本体セッションに修正を挟めない）。ループ制御・収束判定・3 ラウンドごとの上限チェックは SKILL.md の既存骨格（codex 系と共通）に置いた
+4. **レビュー観点は codex 系テンプレートと同一の 7 観点** — 系統によってレビュー品質基準が変わらないよう、`assets/codex-review-prompt.md` の観点を逐語で雛形プロンプトに移植し、両ファイルに同期ノートを付けた
+5. **両フラグ併用時は codex 優先** — smart-issue-plan と同じ判断基準（別系統モデルの独立性がより高い）+ 1 行通知
+6. **codex 系フォールバックで claude 系へ自動切替しない** — smart-issue-plan と同じ（codex フラグ明示 = ユーザーが別系統モデルを選んでいる。`-cldrl` での再実行を案内するに留める）。memory-dream にはセキュリティ自動発動が無いため、自動切替が正当化されるケースも無い
+7. **args シム（`typeof args === 'string' ? JSON.parse(args) : ...`）を雛形に内蔵** — 「Workflow の args が JSON 文字列で届く環境がある」既知問題（#76）への対応。既存雛形は起動時にシムを挿入する運用だが、新規作成分は最初から内蔵した（JSON 値で届く環境でも無害）
+
+## CLAUDE.md「レビュープロンプトの二重化と同期」マスターリストに追加しなかった理由
+
+マスターリストの対象は「敵対レビューの Breaker / Judge プロンプト（攻撃観点・4 分類裁定基準）と標準レビュー観点の骨格」（コードレビュー系）。memory-dream のレビュー観点は記憶 consolidation 専用（hallucination 混入・誤削除・日付変換・レイヤ重複など）で、この骨格とは別物。同期はスキル内（codex テンプレート ↔ claude 雛形）で閉じるため、両ファイルの同期ノートで管理する。
+
+## 検証
+
+- 雛形 js ブロックの構文チェック（CLAUDE.md 記載の awk + `node --check`）: OK
+- `npx skills add ./ --list`: memory-dream が更新後 description で検出されること: OK
+- Workflow スモークテスト: ダミー記憶リポジトリに欠陥 2 件（相対日付の誤変換・出典のない新事実）を仕込んだ dream 差分を作り、雛形をそのまま起動してレビュー結果（FINDINGS_SCHEMA 準拠）を確認
+- 実運用フロー（実際の dream → ループ収束）での end-to-end 検証は未実施（必要なら empirical-prompt-tuning で別途チューニングする）
+
+## その他
+
+- Codex による最終レビューはユーザー指示により省略した

--- a/skills/memory-dream/README.md
+++ b/skills/memory-dream/README.md
@@ -7,6 +7,7 @@ git 管理された記憶階層（MEMORY.md・notes・projects 等）を再編�
 ```
 /memory-dream
 /memory-dream --codex-review-loop
+/memory-dream --claude-review-loop   # または -cldrl（Codex 不要）
 ```
 
 副作用（記憶ファイルの書き換え・commit）があるため `disable-model-invocation: true` を設定している。Claude Code ではユーザーの `/memory-dream` でのみ起動する（他エージェントはこのフラグを無視するため、「記憶を整理して」「dream して」でも起動しうる）。
@@ -16,6 +17,9 @@ git 管理された記憶階層（MEMORY.md・notes・projects 等）を再編�
 | オプション | 説明 |
 |---|---|
 | `--codex-review-loop`（`-cdxrl`） | ユーザーレビュー依頼の前に、dream の全差分を Codex（`codex:rescue`）による独立レビューループにかける（Claude Code + Codex プラグイン環境前提）。収束・打ち切りとなってもユーザーの採用前レビューは省略しない |
+| `--claude-review-loop`（`-cldrl`） | 同上のレビューループを、コンテキスト隔離した Sonnet（effort max）レビュワーエージェントで実施する（Codex 不要・Claude Code の Workflow ツール前提）。レビュー観点は codex 系と同一。別系統モデルの独立性はないため、Codex が使える環境では `-cdxrl` を推奨 |
+
+> 両方指定した場合は codex 系を優先する（別系統モデルの独立性がより高い）。
 
 ## 動作内容
 
@@ -24,7 +28,7 @@ git 管理された記憶階層（MEMORY.md・notes・projects 等）を再編�
 3. **Consolidate（統合）**: 既存記憶へマージ。相対日付 → 絶対日付（基準日は git 履歴で特定）、矛盾は最新値で解決、消滅した参照は参照先リポジトリで現存確認のうえ除去
 4. **Dedup & Resolve（重複排除・矛盾解消）**: 階層をまたぐ重複を下位レイヤ側から除去。真の矛盾はユーザー確認
 5. **Prune & Index（剪定・索引化）**: 索引を lean 化（目安 200 行未満）、notes 一覧を再生成・同期
-6. 論理単位ごとに commit し、チェックリストで自己検証。`--codex-review-loop` 指定時は Codex レビューループ（採用 0 件まで、3 ラウンドごとに継続確認）を実施
+6. 論理単位ごとに commit し、チェックリストで自己検証。`--codex-review-loop` / `--claude-review-loop` 指定時はレビューループ（採用 0 件まで、3 ラウンドごとに継続確認）を実施
 7. ユーザーの採用前レビューへ（push は明示指示まで保留）
 
 ## 前提条件（依存する機能）
@@ -33,16 +37,17 @@ git 管理された記憶階層（MEMORY.md・notes・projects 等）を再編�
 - **ファイル編集ツール（Edit / Write）** — 記憶ファイルの書き換えに必須
 - **AskUserQuestion** — 真の矛盾・レビューループ継続のユーザー確認に使用（Claude Code 拡張。他エージェントではテキスト確認にフォールバック）
 - **セッション transcript へのアクセス** — Phase 1（Mine）の材料（任意。参照できない場合は現在の会話と既存記憶のみで実施）
-- **Codex プラグイン（`codex:rescue` スキル）** — `--codex-review-loop` 使用時のみ必須（Claude Code + Codex CLI 設定済み環境前提）。利用不能時は「Codex レビュー未実施」と明示してユーザーレビューのみに切り替える（Claude がレビューを代行しない）
+- **Codex プラグイン（`codex:rescue` スキル）** — `--codex-review-loop` 使用時のみ必須（Claude Code + Codex CLI 設定済み環境前提）。利用不能時は「Codex レビュー未実施」と明示してユーザーレビューのみに切り替える（Claude がレビューを代行せず、claude 系へも勝手に切り替えない）
+- **Workflow ツール** — `--claude-review-loop` 使用時のみ必須（Claude Code 固有。利用できない環境では「Claude レビュー未実施」と明示してユーザーレビューのみに degrade する）
 - 環境の常時ロード指示（AGENTS.md / CLAUDE.md / MEMORY.md 等）が記憶階層の場所と各レイヤの役割を定義していること（特定できない場合はユーザーに確認して停止する）
 
 ## 安全性
 
 - **入力非破壊**: 変更は論理単位ごとの commit に分離し、revert 可能な状態を保つ。push はユーザーの明示指示まで保留
 - 更新禁止レイヤ（Phase 0 で列挙したもの。例: AGENTS.md）は変更せず、commit 前に `git diff --name-only` で機械的に確認する。設計文書（構成例の `specs/` 等）も原則触らない
-- consolidation の出力には hallucination が混入しうる前提で、採用前のユーザーレビューをフローに組み込んでいる（`--codex-review-loop` はその前段の独立レビュー）
+- consolidation の出力には hallucination が混入しうる前提で、採用前のユーザーレビューをフローに組み込んでいる（`--codex-review-loop` / `--claude-review-loop` はその前段の独立レビュー）
 
 ## 関連スキル
 
-- `codex:rescue` — `--codex-review-loop` のレビュアーとして呼び出される Codex 連携スキル
+- `codex:rescue` — `--codex-review-loop` のレビュアーとして呼び出される Codex 連携スキル（`--claude-review-loop` は Workflow ツールで隔離 Sonnet レビュワーを起動するため Codex 不要）
 - `/code-reviewer-adversarial` — コード変更向けの敵対的レビュー（memory-dream のレビューループは記憶差分向けの標準レビュー）

--- a/skills/memory-dream/SKILL.md
+++ b/skills/memory-dream/SKILL.md
@@ -7,9 +7,11 @@ description: >
   「記憶を整理して」「dream して」「/memory-dream」で起動。
   --codex-review-loop（-cdxrl）を付けると採用前に Codex レビューループを実施する
   （Claude Code + Codex プラグイン環境前提）。
-argument-hint: "[--codex-review-loop|-cdxrl]"
+  --claude-review-loop（-cldrl）はコンテキスト隔離した Sonnet（effort max）レビュワーエージェントによる
+  レビューループを実施する（Codex 不要・Claude Code の Workflow ツール前提。利用できない環境はレビュー未実施で degrade）。
+argument-hint: "[--codex-review-loop|-cdxrl] [--claude-review-loop|-cldrl]"
 disable-model-invocation: true
-allowed-tools: Read, Bash, Glob, Grep, Edit, Write, AskUserQuestion
+allowed-tools: Read, Bash, Glob, Grep, Edit, Write, AskUserQuestion, Workflow
 ---
 
 # memory dream（記憶の整理 / consolidation）
@@ -20,10 +22,13 @@ git 管理された記憶階層を定期的に再編し、重複・矛盾・陳�
 
 `$ARGUMENTS` を解析する:
 
-- `--codex-review-loop` または `-cdxrl` → `{レビューモード}` を `standard` にする
+- `--codex-review-loop` または `-cdxrl` → `{レビューモード}` = `standard`、`{レビュー系統}` = `codex`
+- `--claude-review-loop` または `-cldrl` → `{レビューモード}` = `standard`、`{レビュー系統}` = `claude`
+- 両方指定された場合 → `{レビュー系統}` は `codex` を優先し（別系統モデルの独立性がより高い）、その旨を 1 行通知する
 - 指定がない場合 → `{レビューモード}` は `off`
 
-例: `/memory-dream --codex-review-loop` → レビューモード: standard
+例: `/memory-dream --codex-review-loop` → レビューモード: standard、系統: codex
+例: `/memory-dream -cldrl` → レビューモード: standard、系統: claude
 
 ## これは何か / なぜ必要か
 
@@ -34,7 +39,7 @@ Dreams は人間の REM 睡眠による記憶定着のメタファ。過去セ�
 ## 原則
 
 1. **入力非破壊**: 変更は論理単位ごとの commit に分離し、revert 可能な状態を保つ。push はユーザーの明示指示まで保留する
-2. **採用前レビュー必須**: consolidation の出力には hallucination が混入しうる。commit をユーザーがレビューしてから採用する（`{レビューモード}` が `standard` の場合は、その前段に Codex レビューループを挟む）
+2. **採用前レビュー必須**: consolidation の出力には hallucination が混入しうる。commit をユーザーがレビューしてから採用する（`{レビューモード}` が `standard` の場合は、その前段に独立レビューループ〔codex 系 / claude 系〕を挟む）
 3. **記憶の再編であって fine-tune ではない**: 変わるのは外部記憶のみ。モデルは変わらない
 
 ## Phase 0: 対象階層の確認（ゲート）
@@ -95,7 +100,7 @@ Dreams は人間の REM 睡眠による記憶定着のメタファ。過去セ�
   find notes -type f -name '*.md' | sort
   ```
 
-論理単位の編集が完了するたびに commit する（複数フェーズが同一ファイルを触るため、フェーズごとに commit を挟むとよい）。全フェーズ完了後、チェックリストで自己検証し、`{レビューモード}` が `standard` なら「Codex レビューループ」を実施してから、ユーザーへレビューを依頼する（push はしない）。
+論理単位の編集が完了するたびに commit する（複数フェーズが同一ファイルを触るため、フェーズごとに commit を挟むとよい）。全フェーズ完了後、チェックリストで自己検証し、`{レビューモード}` が `standard` なら「レビューループ（codex 系 / claude 系）」を実施してから、ユーザーへレビューを依頼する（push はしない）。
 
 ## 重複排除の判定ルール
 
@@ -116,7 +121,7 @@ Dreams は人間の REM 睡眠による記憶定着のメタファ。過去セ�
 
 ## チェックリスト
 
-ユーザーへレビューを依頼する前（`{レビューモード}` が `standard` の場合は Codex レビューループの前）に全項目を確認する:
+ユーザーへレビューを依頼する前（`{レビューモード}` が `standard` の場合はレビューループの前）に全項目を確認する:
 
 - [ ] 相対日付をすべて絶対日付へ変換した（基準日は git 履歴で特定。特定できないものは変換せずユーザー確認へ回した）
 - [ ] 上位が定めるルールを下位から削った（重複回避の注記自体も残していない）
@@ -129,19 +134,23 @@ Dreams は人間の REM 睡眠による記憶定着のメタファ。過去セ�
 - [ ] 変更を論理単位ごとに commit した（push はしていない）
 - [ ] ユーザーレビューを経てから採用する（dream 出力は hallucination 混入の懸念があるため鵜呑みにしない）
 
-## Codex レビューループ（--codex-review-loop）
+## レビューループ（--codex-review-loop / --claude-review-loop）
 
-`{レビューモード}` が `standard` の場合、チェックリストの自己検証後・ユーザーへのレビュー依頼前に実施する。別系統モデル（Codex）による独立レビューが目的のため、**Claude 自身が Codex のレビューを模擬・代行してはならない**。返ってきた指摘の採用 / 不採用（過剰対応かどうか）の判定は、レビュイーである Claude が行う。
+`{レビューモード}` が `standard` の場合、チェックリストの自己検証後・ユーザーへのレビュー依頼前に実施する。目的は **dream 実施の文脈から独立したレビュー**。codex 系は別系統モデル（Codex）が、claude 系はコンテキスト隔離した Sonnet エージェント（effort max）がレビューを担う。**Claude 自身（オーケストレーター）がレビューを模擬・代行してはならない**。返ってきた指摘の採用 / 不採用（過剰対応かどうか）の判定は、いずれの系統でもレビュイーである Claude（オーケストレーター）が行う。
 
-1. **レビュー取得** — [assets/codex-review-prompt.md](assets/codex-review-prompt.md) のテンプレートを埋め、Skill ツールで `codex:rescue` を呼び出す。Codex が dream の全差分（`git diff <開始時 HEAD>..HEAD`）を記憶階層の git 履歴と照合してレビューする
+1. **レビュー取得** — `{レビュー系統}` に応じて取得する:
+   - **codex 系** — [assets/codex-review-prompt.md](assets/codex-review-prompt.md) のテンプレートを埋め、Skill ツールで `codex:rescue` を呼び出す。Codex が dream の全差分（`git diff <開始時 HEAD>..HEAD`）を記憶階層の git 履歴と照合してレビューする
+   - **claude 系** — 雛形 `md-dream-review`（[references/agent-orchestration.md](references/agent-orchestration.md)）を Workflow ツールで起動する（1 起動 = 1 ラウンド。レビュー観点は codex 系と同一）。返却が `status: 'agent-failed'` の場合は 1 回だけ `resumeFromRunId` で再開し、それでも失敗ならフォールバック（claude 系）へ
 2. **妥当性判定** — 指摘を 1 件ずつ「採用 / 不採用」に分類する。不採用（妥当性がない・過剰対応・スコープ外）の理由は 1 行で記録する
 3. **修正** — 採用指摘を反映し、修正 commit を積む（既存 commit は書き換えない）
 4. **収束判定** — 採用が 0 件ならループ終了（収束）。1 件以上なら手順 5（上限チェック）へ進む（**必ず上限チェックを経由する**。直接手順 1 へ戻らない）
 5. **上限チェック** — ラウンド数が 3 の倍数（3, 6, …）に達したら、残指摘の要約を提示して AskUserQuestion で「続行 / 打ち切り / 中止」を確認する。達していなければラウンドを +1 して手順 1 へ戻る
 
-ループが収束・打ち切りとなっても、**ユーザーの採用前レビュー（原則 2）は省略しない**。レビュー依頼時にラウンド数・採用/不採用件数の要約を添える。
+ループが収束・打ち切りとなっても、**ユーザーの採用前レビュー（原則 2）は省略しない**。レビュー依頼時に系統・ラウンド数・採用/不採用件数の要約を添える。
 
-### フォールバック（codex:rescue 利用不能時）
+> claude 系の独立性は**コンテキスト隔離**で担保する（レビュワーは dream を実施していない fresh エージェント）。codex 系のような別系統モデルの独立性はないため、利用できる環境では codex 系を推奨する。
+
+### フォールバック（codex 系: codex:rescue 利用不能時）
 
 以下のいずれかに該当する場合に実施する:
 
@@ -151,7 +160,14 @@ Dreams は人間の REM 睡眠による記憶定着のメタファ。過去セ�
 該当した場合:
 
 - Claude 自身でレビューを代行しない
-- 「Codex レビュー未実施」とユーザーに明示し、通常どおりユーザーの採用前レビューへ進む
+- claude 系へ勝手に切り替えない（ユーザーは別系統モデルのレビューを選んでいる）。「Codex レビュー未実施」とユーザーに明示し、必要なら `-cldrl` での再実行を案内して、通常どおりユーザーの採用前レビューへ進む
+
+### フォールバック（claude 系: Workflow 利用不能時）
+
+Workflow ツールが無い環境、または `resumeFromRunId` での再開後も `status: 'agent-failed'` の場合:
+
+- Claude 自身（オーケストレーター）でレビューを代行しない
+- 「Claude レビュー未実施」とユーザーに明示し、通常どおりユーザーの採用前レビューへ進む
 
 ## いつ実施するか
 

--- a/skills/memory-dream/assets/codex-review-prompt.md
+++ b/skills/memory-dream/assets/codex-review-prompt.md
@@ -1,6 +1,8 @@
 # Codex レビュー依頼テンプレート（memory dream 差分）
 
-標準モード（`--codex-review-loop`）のループ手順 1 で `codex:rescue` に渡す依頼文のテンプレート。`<>` を埋めて task として渡す。
+codex 系（`--codex-review-loop`）のループ手順 1 で `codex:rescue` に渡す依頼文のテンプレート。`<>` を埋めて task として渡す。
+
+> **同期ノート**: 「レビュー観点」7 項目と「制約」は、claude 系雛形 [references/agent-orchestration.md](../references/agent-orchestration.md)（`md-dream-review`）のレビュワープロンプトと同一の観点を持つ。片方を変えたらもう片方も更新すること。
 
 ---
 

--- a/skills/memory-dream/references/agent-orchestration.md
+++ b/skills/memory-dream/references/agent-orchestration.md
@@ -1,0 +1,94 @@
+# エージェントオーケストレーション（dream 差分レビュー用 Workflow スクリプト雛形）
+
+memory-dream の **claude 系レビューループ**（`--claude-review-loop`）を担うレビュワーエージェントの起動手順と Workflow スクリプト雛形。SKILL.md の「レビューループ」節から参照される。**Claude Code の Workflow ツール前提**（利用できない環境の degradation は SKILL.md のフォールバックを参照）。
+
+> dream 本体（Phase 0〜4）・指摘の妥当性判定・修正 commit はオーケストレーター（メインセッション）が従来どおり担う。本ファイルの雛形が起動するのは**コンテキスト隔離されたレビュワーによる 1 ラウンド分のレビュー**のみ。ループ制御（収束判定・3 ラウンドごとの上限チェック）は SKILL.md 側の骨格で行う。
+
+## 前提とゲート
+
+- 起動前に Phase 0 の inventory（`${TMPDIR:-/tmp}/memory-dream-inventory.md`）が存在し、dream の全変更が commit 済みであること（レビュー対象は `git diff <開始時 HEAD>..HEAD`）
+- スクリプトはこのファイルの雛形を**そのまま** `script` に渡し、可変値はすべて `args` で渡す（スクリプト本文を書き換えない。プロンプト文はスクリプトに内蔵済み）
+- `args` は JSON 値として渡す（文字列化した JSON を渡さない。届いた `args` が文字列でも雛形冒頭のシムが吸収する）
+- Workflow スクリプト内では `Date.now()` / `Math.random()` / 引数なし `new Date()` は使えない（雛形は使用していない）
+- ツール結果に返る `scriptPath` を控えておくと、2 ラウンド目以降は `{scriptPath, args}` で再送できる。中断・失敗からの再開は `resumeFromRunId` を使う
+
+## 雛形: dream 差分レビュー（md-dream-review）
+
+1 起動 = 1 ラウンド。隔離された Sonnet（effort max）レビュワーが dream 差分を記憶階層の git 履歴と照合してレビューし、構造化された指摘を返す。指摘の採用 / 不採用の判定と修正 commit はオーケストレーターが行う（レビュワーはファイルを変更しない）。
+
+`args`: `{ memoryRoot, startHead, inventoryPath, round, workSummary, priorSummary }`
+（`memoryRoot`: 記憶階層ルートの絶対パス。`startHead`: dream 開始時 HEAD の commit hash。`inventoryPath`: Phase 0 の inventory ファイルの絶対パス。`round`: 通算ラウンド番号（1, 2, …）。`workSummary`: Mine で抽出した事実・Consolidate / Dedup で行った主な変更の要約。`priorSummary`: 前ラウンドまでに採用した指摘と反映内容の要約（初回は空文字））
+
+```js
+export const meta = {
+  name: 'md-dream-review',
+  description: 'memory-dream claude 系レビューループの 1 ラウンド（隔離 Sonnet レビュワーによる dream 差分レビュー）',
+  phases: [
+    { title: 'Review', detail: 'Sonnet（effort max）レビュワーが dream 差分を git 履歴と照合' },
+  ],
+}
+
+const $a = typeof args === 'string' ? JSON.parse(args) : (args || {})
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['items'],
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'severity', 'basis', 'detail'],
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['High', 'Medium', 'Low'] },
+          basis: { type: 'string', description: 'ファイルパス・行・照合した commit など一次情報' },
+          detail: { type: 'string', description: '何が問題か・どう直すべきか' },
+        },
+      },
+    },
+  },
+}
+
+const prior = $a.priorSummary
+  ? `\n### 3. 前ラウンドまでの経緯（採用した指摘と反映内容の要約）\n${$a.priorSummary}\n`
+  : ''
+
+const findings = await agent(`あなたはエージェント記憶階層の consolidation（memory dream）結果のレビュワーである。dream の実施には関与していない独立の立場から、記憶階層リポジトリの git 履歴・内容と照合し、dream 差分の欠陥のみを指摘する。
+## 入力
+### 1. 記憶階層
+- ルート: ${$a.memoryRoot}
+- レビュー対象差分: ルートで \`git diff ${$a.startHead}..HEAD\` を実行して取得する
+- レイヤ構成と更新禁止レイヤ: ${$a.inventoryPath} を読む（dream 開始時に作成された inventory）
+### 2. dream の作業要約（ラウンド ${$a.round}）
+${$a.workSummary}
+${prior}
+## レビュー観点
+- 更新禁止レイヤへの変更: 差分に更新禁止レイヤ（inventory に記載）のファイルが含まれていないか
+- hallucination の混入: 差分で追加・書き換えられた記述に、git 履歴・既存記憶のどこにも出典がない「新事実」が混入していないか
+- 誤削除: 削除された記述のうち、現存する参照・現行で有効な知見が含まれていないか（参照先の実在は git 履歴・リポジトリ内容から検証する）
+- 日付変換の誤り: 相対日付 → 絶対日付の変換が、当該行の追記 commit 日時（git log / git blame）と整合しているか
+- 矛盾解決の新旧誤り: 矛盾の解決で「古い側」の値が採用されていないか（当該行の追記日時で検証する）
+- 重複・経緯の残留: 上位レイヤのルール再掲、経緯・履歴（Why / 失敗談 / 学習日・セッション ID 等）、重複回避のメタ注記が成果ファイルに残っていないか
+- 索引の同期漏れ: 索引（MEMORY.md 系・notes 一覧）とファイル実体が一致しているか
+## 制約
+- 指摘は dream 差分の欠陥に限定する（dream 以前から存在する記憶の欠陥・文体・好みは対象外）
+- 各指摘に根拠（ファイルパス・行・照合した commit など一次情報）と重大度を付ける
+- 記憶階層のファイルを変更しない（レビューのみ）。コミット・push はしない
+- 指摘が無ければ items を空配列にする`,
+  { label: `dream-reviewer:r${$a.round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
+
+if (findings === null) return { status: 'agent-failed', items: [] }
+return { status: 'ok', items: findings.items }
+```
+
+返却の扱い:
+
+- `status: 'ok'` → `items` を SKILL.md のループ骨格・手順 2（妥当性判定）に渡す。`items` が空配列ならそのラウンドは指摘 0 件（採用 0 件 = 収束）
+- `status: 'agent-failed'` → 1 回だけ `resumeFromRunId` で再開し、それでも失敗なら SKILL.md の「フォールバック（claude 系）」へ
+
+## 同期ノート
+
+- 雛形内のレビュワープロンプト（レビュー観点 7 項目・制約）は [assets/codex-review-prompt.md](../assets/codex-review-prompt.md) の codex 系テンプレートと**同一の観点**を持つ。片方を変えたらもう片方も更新すること（系統によってレビュー観点が変わらないことが同期の目的）
+- 本雛形は memory-dream 専用の標準レビュー（記憶差分向け観点）であり、コードレビュー系スキルの観点骨格（CLAUDE.md「レビュープロンプトの二重化と同期」のマスター対象）とは**意図的に別物**。同マスターリストへの同期対象ではない
+- 冒頭の `$a` シムは「Workflow の `args` が JSON 文字列で届く環境がある」既知問題（#76）への対応。恒久修正が入っても無害（JSON 値で届けばそのまま通す）


### PR DESCRIPTION
## 概要

memory-dream スキルに、smart-issue-plan と同様の **claude 系レビューループ**（`--claude-review-loop` / `-cldrl`）を追加する。Codex 不在環境でも、コンテキスト隔離した Sonnet（effort max）レビュワーエージェントで dream 差分の独立レビューループを回せるようにする。

## 変更内容

- **`references/agent-orchestration.md`（新規）**: Workflow 雛形 `md-dream-review`。1 起動 = 1 ラウンドで隔離 Sonnet レビュワーが dream 差分を git 履歴と照合し、構造化指摘（FINDINGS_SCHEMA）を返す。`args` が JSON 文字列で届く既知問題（#76）へのシムを冒頭に内蔵
- **`SKILL.md`**: 引数解析に `{レビュー系統}` を導入（両フラグ併用時は codex 優先）。レビューループ節を codex 系 / claude 系の共通骨格に再構成し、claude 系フォールバック（Workflow 利用不能時）を追加。`allowed-tools` に Workflow を追加
- **`assets/codex-review-prompt.md`**: claude 系雛形とのレビュー観点同期ノートを追加
- **`README.md`**: オプション表・前提条件（Workflow ツール）・系統併用時の優先規則を追記
- **実装ノート**: `docs/implementation-notes/2026-07-07-memory-dream-claude-review-loop.md`（standard のみ追加・レビュイー不変則の維持・1 起動 1 ラウンド構造などの判断を記録）

## 設計上の判断（詳細は実装ノート）

- 依頼どおり **standard のみ**追加（memory-dream の codex 系に敵対的モードが無いため、モード体系は変えない）
- 採用 / 不採用の判定と修正 commit は**レビュイーであるオーケストレーター**が担う既存不変則を維持（隔離するのはレビュワーのみ）
- レビュー観点は codex 系テンプレートと**同一の 7 観点**（スキル内同期ノートで管理。CLAUDE.md のレビュープロンプト同期マスターリストはコードレビュー系観点が対象のため追加せず）

## 検証

- 雛形 js ブロックの構文チェック（awk + `node --check`）: OK
- `npx skills add ./ --list`: 更新後 description で検出: OK
- **Workflow スモークテスト**: 欠陥 2 件（出典なし新事実・相対日付の誤変換）を仕込んだダミー記憶リポジトリで雛形をそのまま起動 → 両方 High で検出（git 履歴から正しい変換先 2026-07-02 を導出）+ 索引同期漏れ（Low）も指摘。スキーマ準拠の返却・args 文字列シムの動作を確認
- Codex 最終レビューはユーザー指示により省略

🤖 Generated with [Claude Code](https://claude.com/claude-code)