### PR TITLE
chore(skills): 旧プラグイン名 mjc-code-develop-tools の残骸を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,6 @@ npx skills update
 - pin した install は lock に ref が記録され、`npx skills update` も pin に従う（タグ pin は据え置き）。新しいタグへ上げるときは `#v<新タグ>` で再 add する。
 - 内部 skill `auto-release`（本リポジトリ専用のリリース用）は `internal/` 配下にあり配布対象外（リモート探索・`--skill '*'` のいずれにも含まれない）。
 
-### 旧 marketplace からの移行
-
-旧 `/plugin install` は**パッケージ単位**、新 `npx skills` は**skill 単位**。旧パッケージに含まれていた skill を `--skill` で指定し直す:
-
-| 旧（廃止） | 新（`npx skills add mjcreativelab/mjcreativelab-agent-prompts ... -g`） |
-|---|---|
-| `/plugin install mjc-git-workflow-tools@…` | `--skill smart-commit --skill smart-pr --skill smart-git-sync --skill smart-issue-resolve --skill smart-issue-plan --skill smart-review --skill smart-review-apply` |
-| `/plugin install mjc-claude-improver-tools@…` | `--skill skill-improver --skill empirical-prompt-tuning --skill claude-code-update-review` |
-| `/plugin install mjc-code-develop-tools@…` | `--skill software-architect --skill code-reviewer --skill code-reviewer-adversarial --skill security-auditor` |
-| `/plugin install mjc-design-tools@…` | `--skill game-ui-design` |
-
 ## ライセンス
 
 [MIT](LICENSE)

--- a/skills/code-reviewer-adversarial/SKILL.md
+++ b/skills/code-reviewer-adversarial/SKILL.md
@@ -218,7 +218,7 @@ Phase 4 で Phase 3 の最終出力を PR へ投稿する際の仕様。
 {Phase 3 の最終出力をそのままコピーして貼る。サマリ / 🚫 真の欠陥 / ❓ 仕様未定 / 📉 低優先度 / 🔇 ノイズ / 💡 修正推奨の順序}
 
 ---
-_このレビューは Claude Code プラグイン `mjc-code-develop-tools` が生成しました。approve / request_changes 判断は含みません。_
+_このレビューは Claude Code スキル `/code-reviewer-adversarial` が生成しました。approve / request_changes 判断は含みません。_
 ````
 
 - 識別マーカー `<!-- claude-code-review:code-reviewer-adversarial -->` は必ず先頭に入れる（HTML コメントなので PR 表示上は不可視）

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -136,7 +136,7 @@ allowed-tools: Read, Bash, Grep, Glob, AskUserQuestion, Workflow
 {「出力フォーマット」で生成した 5 区分（🚫 / ⚠️ / 💬 / ✅ / 🔄 横断影響）の markdown をそのまま埋め込む。該当すれば「Codex クロスチェック推奨」節も含める}
 
 ---
-_このレビューは Claude Code プラグイン `mjc-code-develop-tools` が生成しました。approve / request_changes 判断は含みません。_
+_このレビューは Claude Code スキル `/code-reviewer` が生成しました。approve / request_changes 判断は含みません。_
 ````
 
 - 識別マーカー `<!-- claude-code-review:code-reviewer -->` は必ず先頭に入れる（HTML コメントなので PR 表示上は不可視）


### PR DESCRIPTION
## 概要
v2.0.0 で撤去済みの旧 marketplace プラグイン名 `mjc-code-develop-tools` の残骸が README とレビュー生成テンプレートに残っていたため削除する。

## 変更内容
- README.md: 旧marketplaceからの移行セクション（`mjc-code-develop-tools` を含む旧プラグイン移行表）を丸ごと削除
- skills/code-reviewer/SKILL.md: PR投稿テンプレートの帰属文言を `mjc-code-develop-tools` から `/code-reviewer` スキル名参照に変更
- skills/code-reviewer-adversarial/SKILL.md: 同様に `/code-reviewer-adversarial` スキル名参照に変更

## レビュアー向け補足
- 移行表全体を削除した理由: v2.0.0 移行から時間が経過し、旧プラグイン名（`mjc-git-workflow-tools` 等）を含む他の行も含めて実質的な参照価値が薄いと判断し、セクション全体を削除した
- 紐づく Issue は無し