### PR TITLE
fix(skills): 敵対レビューの単一 Judge を scenario バッチ並列裁定に分割（180s watchdog ストール解消）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ skill（例: `code-reviewer-adversarial` の Codex 連携）は、その旨を d
 - `-p` 等のオプション引数を持つスキルには「引数の解析」セクションを設ける（smart-commit の形式を参照）。同一グループ内で引数パースの書き方を統一すること
 - スキル改修時は frontmatter を確認する: 副作用のあるスキルに `disable-model-invocation: true` があるか、`allowed-tools` が設定されているか、`description` に類似スキルとの差別化文言があるか
 - **レビュープロンプトの二重化と同期（マスター）**: 敵対レビューの Breaker / Judge プロンプト（攻撃観点・4 分類裁定基準）と標準レビュー観点の骨格は、スキル間ファイル参照不可・Skill 合成不可の制約から意図的に複数スキルへ二重化している。次のいずれかを変更したら対応箇所をすべて同期すること（可読性を観点に含めるか等、各スキルの identity として意図的に異なる部分は除く）:
-  - `smart-issue-resolve/references/agent-orchestration.md` — 雛形 B（`sir-claude-review-set`）の reviewerPrompt / breakerPrompt / judgePrompt、雛形 C（`sir-codex-breaker`）の Breaker
+  - `smart-issue-resolve/references/agent-orchestration.md` — 雛形 B（`sir-claude-review-set`）の reviewerPrompt / breakerPrompt / judgeBatchPrompt、雛形 C（`sir-codex-breaker`）の Breaker
   - `smart-issue-plan/references/agent-orchestration.md` — `sip-plan-review-set`（計画テキスト用に適応した変種）
   - `code-reviewer/references/agent-orchestration.md` — `--isolated` の単発隔離レビュー（`cr-isolated-review`）
   - `code-reviewer-adversarial/references/agent-orchestration.md` — `--claude-judge` の Breaker×Judge（`cra-claude-judge`）

--- a/docs/implementation-notes/2026-07-13-issue-88-judge-batch-parallel.md
+++ b/docs/implementation-notes/2026-07-13-issue-88-judge-batch-parallel.md
@@ -1,0 +1,84 @@
+# 実装ノート — Issue #88（敵対レビューの単一 Judge をバッチ並列化）
+
+- 日付: 2026-07-13 / ブランチ: `fix/issue-88-judge-batch-parallel`
+- 目的: claude 系敵対レビューループの単一 Judge が「多数シナリオ × 無限定な全サービス横断照合 × effort: 'max'」で harness の 180s/step 無進捗ウォッチドッグにストールする問題を、Breaker 出力を ≤4 件/バッチに分割した並列 Judge へ置き換えて構造的に解消する（Issue 本文の案 A・実セッション検証済み）。
+
+## 変更ファイル
+
+- `skills/smart-issue-resolve/references/agent-orchestration.md`（雛形 B `sir-claude-review-set`）
+  - `judgePrompt(round, breaker)` → `judgeBatchPrompt(round, batch, batchNum, batchTotal)` へ置換（単一呼び出し用の旧 `judgePrompt` は dead code のため削除）
+  - ループ内の単一 Judge 呼び出しを、`breaker.counterexamples` を ≤4 件/バッチに分割し `parallel` で並列裁定するバッチ block へ置換
+  - 部分バッチ失敗の劣化フラグ `judgeDegraded` を追加（宣言・部分失敗ブランチで set・返却・返却の扱いに「収束時も自動コミット前にユーザー確認」を明記）。設計整合レビュー指摘 1 の反映（後述の判断事項 8）
+  - 同期ノート: 「両者で同期する構造」に敵対モード Judge のバッチ並列化と `judgeDegraded` の伝播を追記。プロンプト移植リストの `judgePrompt` 表記を `judgeBatchPrompt` に更新（裁定基準不変のため単体スキルへの同期は不要である旨も明記）
+- `skills/smart-issue-plan/references/agent-orchestration.md`（雛形 `sip-plan-review-set`）
+  - `judgePrompt` → `judgeBatchPrompt` へ置換（計画用の「実コード＋計画本文照合」「反例テスト無し」の差分は維持）
+  - 単一 Judge 呼び出しを、`breaker.scenarios` を ≤4 件/バッチに分割する同型バッチ block へ置換
+  - 部分バッチ失敗の劣化フラグ `judgeDegraded` を追加（返却・返却の扱い・完了報告・SKILL.md の返却の扱いに反映。`plan.md` 投稿前のユーザー確認を明記）
+  - 同期ノートの「同期する構造」リストにバッチ並列 Judge と `judgeDegraded` の伝播を追記（Breaker フィールド名だけ意図的に異なる旨も明記: resolve=`counterexamples` / plan=`scenarios`）
+- `skills/smart-issue-resolve/SKILL.md`（4 箇所・effort/構造の最小更新）
+  - 役割表の「Breaker / Judge（敵対）」行を `sonnet / max・high`（Breaker=max / Judge=high・バッチ並列）に更新
+  - レビューループ節の「(effort max) がレビュー・裁定を担う」一般記述に、敵対 Judge のバッチ並列 high を注記
+  - claude 系敵対モード説明の Judge を `effort max` → `effort high`・バッチ並列に更新（ストール防止の意図を 1 文追記）
+  - 「収束後のコミット・PR 作成」の最終 QA ゲートに `judgeDegraded: true` 時のユーザー確認を明記（判断事項 9）
+- `skills/smart-issue-resolve/README.md`（2 箇所）
+  - 役割表の該当行に「claude 敵対 Judge のみ high・≤4 件/バッチ並列裁定」を注記
+  - claude 敵対の説明を Breaker=max / Judge=high・バッチ並列に更新
+- `skills/smart-issue-plan/SKILL.md`（3 箇所）
+  - レビューループ節の「(effort max)」一般記述に敵対 Judge のバッチ並列 high を注記（resolve SKILL.md と同文の箇所・後述の判断参照）
+  - claude 系敵対モード説明の Judge を effort high・バッチ並列に更新
+  - Workflow 返却の扱いに `judgeDegraded: true`（一部シナリオ未裁定 → 投稿前にユーザー確認）を追記（設計整合レビュー指摘 1）
+- `skills/smart-issue-plan/README.md`（1 箇所）
+  - claude 敵対の説明の Judge を effort high・バッチ並列に更新
+- `CLAUDE.md`（1 箇所・設計整合レビュー指摘 3）
+  - 「スキル改修時の注意 → レビュープロンプトの二重化と同期」マスターの resolve エントリの識別子表記 `judgePrompt` → `judgeBatchPrompt`
+- `docs/implementation-notes/2026-07-13-issue-88-judge-batch-parallel.md`（本ファイル・同 PR）
+
+裁定基準（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準・items/dismissed 振り分け）・標準モード reviewer・Breaker・codex 系（雛形 C / codex-judge-prompt.md）・QA 系は一切変更なし。
+
+## 要件対応（受け入れ基準ごと）
+
+### 完了条件 1: Breaker が 10 件以上出しても Judge がストールせず裁定を完走する構造
+
+達成。各バッチの作業量が有界になるよう次の 3 点で担保した:
+
+1. バッチサイズ上限 `BATCH = 4`。Breaker が N 件出すと ⌈N/4⌉ 個の Judge が **並列**起動し、各 Judge が扱うのは最大 4 件のみ（10 件 → 3 並列、14 件 → 4 並列）。
+2. `judgeBatchPrompt` に「裁定対象はインラインの当バッチのみ・他バッチや `breaker-round-<N>.md` の他項目は読まない」「照合は各シナリオの `evidence` が指すファイル/行に限定・無関係な広域 grep / 全サービス横断探索を禁止」を明示（観測されたストール直接原因への対策）。
+3. 呼び出し側 `effort: 'max'` → `'high'`、プロンプトに「3 分以内に着実に tool を進める」を明示。
+
+### 完了条件 2: plan / resolve 両テンプレートに反映され構造同期が保たれる
+
+達成。両ファイルに同型のバッチ block（`scen` → `batches` 分割 → `parallel` → `filter(Boolean)` → `flatMap` 集約）と `judgeBatchPrompt` を入れた。意図的な差分は Breaker フィールド名のみ（resolve=`counterexamples` / plan=`scenarios`）。両ファイルの同期ノートにバッチ並列化を追記し、構造同期の対象であることを明文化した。
+
+## 自分で判断した事項
+
+1. **バッチ block は Issue / design の検証済みスニペットを逐語採用**（`parallel(thunks)` を `Promise.all` 等へ書き換えない）。design の未確定事項 1（`parallel` の runtime 契約）に従い、独断で書き換えず検証済みの形を保持した。
+2. **agent-failed 経路の担い手**: バッチ版では `findings` は常にオブジェクト（`{items, dismissed}`）になるため、既存の `if (findings === null)` は adversarial では発火しない。Judge 全滅の検知は `batches.length > 0 && ok.length === 0` チェックが担う。部分失敗（一部バッチのみ null）は `log` して部分裁定で続行する。0 件（`batches.length === 0`）は `agent-failed` にせず `findings = {items:[], dismissed:[]}` → 既存の収束判定（`items.length === 0`）に載る。この 3 経路が下流（specQuestions 抽出・records 記録・収束判定・standard 分岐）と無改修で互換であることをコード上で確認した。
+3. **SKILL/README の役割表は「行分割」ではなく「注記」を採用**（design 未確定事項 2）。既存の表構造を保ち effort 列に併記する最小変更に留めた（過剰なリストラクチャを避ける）。
+4. **plan SKILL.md の一般記述（「(effort max) がレビュー・裁定を担う」）も更新**。design の SKILL 更新リストには resolve 側（L213 相当）のみ挙がっていたが、plan SKILL.md にも同文の一般記述が存在し、更新しないと plan/resolve 間で記述の正確性が乖離する。本 Issue の主眼が plan/resolve 構造同期であることから、同文箇所は両方更新して整合を保った（effort/構造記述の最小更新の範囲内）。
+5. **同期ノートの単体スキル同期は不要と明記**。context/design の指示どおり、裁定基準を変えない構造変更のため `code-reviewer`（`cr-isolated-review`）・`code-reviewer-adversarial`（`cra-claude-judge`）への同期はしない。resolve 同期ノートの 2 段落目にその旨を 1 節追記した。
+6. **実装ノートのファイル名は design 指定の `2026-07-13-...` を採用**。作業中に日付が JST で 2026-07-14 に変わったが、design.md が成果物として明示的に命名した `2026-07-13-issue-88-judge-batch-parallel.md` に合わせ、参照整合を優先した。
+7. **CLAUDE.md「スキル改修時の注意」マスターの同期対象一覧の識別子表記を更新**（設計整合レビュー指摘 3 を採用）。初期実装では scope 尊重で未変更としフォローアップ候補に回したが、レビューで「リネーム元 PR で直すのが最小コスト・マスター同期マップの grep 正確性は repo の明示的価値」と判断し、resolve エントリの `judgePrompt` を `judgeBatchPrompt` に更新した（1 語）。単体スキル `code-reviewer-adversarial` は自身の単一 Judge `judgePrompt` を正当に保持するため触れない（移植元表記は下記フォローアップ候補）。
+8. **部分バッチ失敗の劣化伝播 `judgeDegraded` を追加**（設計整合レビュー指摘 1 を採用）。バッチ版は `findings` が常にオブジェクトのため `if (findings === null)` が発火せず、一部の Judge バッチが null（ストール）で生存バッチの真の欠陥 0 件だと収束扱いになる。このとき未裁定の反例（最大 4 件/バッチ）が残るが、初期実装ではログ 1 行のみで返却に伝播していなかった。既存 `auditFailed` と同型に劣化フラグを立てて返却し、返却の扱いで「収束時も自動コミット/`plan.md` 投稿前にユーザー確認」を明記。resolve/plan 両テンプレートに同期。`finalQa` はテスト・受け入れ基準の検証で、敵対レビューが対象とする設計・保守・可用性クラスの未裁定欠陥はバックストップしないため、劣化の可視化に意味がある。
+9. **resolve SKILL.md の「収束後のコミット・PR 作成」最終 QA ゲートにも `judgeDegraded` を明記**（本 PR のレビューループ最終 QA が pass 付帯で推奨した plan/resolve 非対称の解消）。plan SKILL.md は返却の扱い箇条書きに `judgeDegraded` を記載済みだが、resolve SKILL.md で自動コミット手順を規定する当該節のステップ 1 は `finalQa.pass` のみに言及していた。resolve は git commit / push / PR 作成という不可逆な副作用を自動実行する経路のため、この節単独でもゲートが読み取れるよう references の「返却の扱い」と同内容の 1 文を追記した。
+
+## テスト結果（ベースライン比較）
+
+このリポジトリはスキル（Markdown テンプレート）集でユニットテストは無い。context.md のテスト方針に沿って 3 点を実行:
+
+1. **Workflow 雛形の JS 構文チェック**（CLAUDE.md 標準・bash スクリプト経由）:
+   - ベースライン（変更前）: resolve 5 block・plan 1 block すべて `OK`
+   - 変更後: resolve 5 block・plan 1 block すべて `OK`（回帰なし）
+   - 注意: `node --check` は未定義グローバルを検出しないため、この検査は `parallel` の runtime 存在・契約を保証しない（下記リスク 1）。
+2. **skill 検出**: `npx skills add ./ --list` で 19 skills 検出、`smart-issue-plan` / `smart-issue-resolve` とも description 込みで検出継続（frontmatter 非破壊）。
+3. **構造レビュー（手動）**: バッチ境界（0 件→0 バッチ・4 件→1・5 件→2・14 件→4）、部分失敗時の続行ログ、`ok.length === 0` の agent-failed 経路、`findings` の形（`{items, dismissed}`）が下流（specQuestions 抽出・records 記録・収束判定・standard 分岐）と互換であること、plan/resolve 間の構造同期を、両ファイルのループ実コードを読んで確認した。
+
+## リスク・トレードオフ
+
+1. **`parallel` プリミティブ（最重要）**: 既存テンプレートは `agent()`/`log()` のみ使用し、`parallel` は本リポジトリに前例が無い（docs 記載なし）。Workflow runtime が `parallel(thunk配列)` を提供し入力順で結果を返す契約に依存する。Issue が plan 側実セッションで検証済みと明記しているため経験的には確認済みだが、静的検査では実行性を保証できない。実運用（Workflow 実行）での初回検証が残課題。加えて、劣化時の部分裁定続行は「`agent()` が throw せず null を返し、`parallel` が個別失敗で reject せず null-or-object 配列で解決する」no-throw 契約（データフロー節）に依存し、バッチ block は `await parallel(...)` を try/catch で囲まない。契約が崩れる（`agent()` が throw / `parallel` が reject）と Workflow 全体が未捕捉例外で落ちる。この load-bearing 前提も初回実行で検証する（設計整合レビュー指摘 2 の採用部分。逐語スニペット採用のためコード変更はしない）。
+2. **独立 Judge レビューの喪失**: バッチ版では旧裁定タスク 2（Breaker が見落とした欠陥の独立探索）を行わない（クロスバッチ重複回避）。claude 敵対の Judge 独立探索が無くなるトレードオフ。標準 reviewer・codex Judge の独立探索は維持されるため、根治（ストール解消）とのバランスで許容。
+3. **並列度の上限**: シナリオ N 件で ⌈N/4⌉ Judge が同時起動。現実の Breaker 産出は ~10-15 件想定で実害は低いが、極端な件数での同時実行上限は留意。
+
+## フォローアップ候補（本 Issue スコープ外）
+
+1. **`cra-claude-judge`（code-reviewer-adversarial）の同型ストールリスク**: 同じ単一 Judge 構造でストールし得るが、裁定基準を変えない本修正のスコープ外（context 指示どおり変更せず記録）。単体スキルの敵対レビューでも多数シナリオが出る場面では同じバッチ並列化が有効と考えられる。別 Issue 化を推奨。
+2. **`code-reviewer-adversarial` の移植元表記**: SKILL.md / references の「雛形 B の `judgePrompt` からの移植」表記は、resolve のリネーム後わずかに不正確（移植元は現在 `judgeBatchPrompt`）。ただし cra の裁定基準の系譜を指す記述で、cra 自身の単一 Judge は `judgePrompt` のまま正当に残る。機械的にリネームすると cra がバッチ化を採用したと誤読させうるため据え置き、将来判断とする（CLAUDE.md マスターの当該行は本 PR で修正済み）。

--- a/skills/smart-issue-plan/README.md
+++ b/skills/smart-issue-plan/README.md
@@ -39,7 +39,7 @@ GitHub Issue の実装計画を作成・更新するスキル。
 **claude 系**（Codex 不要・Claude Code の Workflow ツールで起動する独立 Sonnet エージェント。コンテキスト隔離 + 役割分離で独立性を担保）:
 
 - **標準（`--claude-review-loop` / `-cldrl`）**: Sonnet（effort max）レビュワーエージェントが単独で計画をレビューする（観点は codex 標準と同一）
-- **敵対的（`--claude-adv-review-loop` / `-cldarl`）**: Breaker（Sonnet / effort max）× Judge（別の Sonnet / effort max）の二者構造。裁定基準は codex Judge と同等（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準）
+- **敵対的（`--claude-adv-review-loop` / `-cldarl`）**: Breaker（Sonnet / effort max）× Judge（別の Sonnet / effort high。攻撃シナリオを ≤4 件/バッチに分割し並列裁定）の二者構造。裁定基準は codex Judge と同等（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準）
 - 別系統モデルの独立性はないため、認証・決済・データスキーマ・外部 API 変更などの重要変更には codex 系を推奨する
 
 共通:

--- a/skills/smart-issue-plan/SKILL.md
+++ b/skills/smart-issue-plan/SKILL.md
@@ -189,7 +189,7 @@ Issue の内容から関連するキーワード・ファイルパス・機能�
 
 ## レビューループ（codex 系 / claude 系）
 
-`{レビューモード}` が `off` 以外の場合に実施する。目的は**計画作成の文脈から独立したレビュー**。codex 系は別系統モデル（Codex）が、claude 系はコンテキスト隔離した Sonnet エージェント（effort max）がレビュー・裁定を担う。**Claude 自身（オーケストレーター）がレビュー・裁定を模擬・代行してはならない**。
+`{レビューモード}` が `off` 以外の場合に実施する。目的は**計画作成の文脈から独立したレビュー**。codex 系は別系統モデル（Codex）が、claude 系はコンテキスト隔離した Sonnet エージェント（effort max。敵対 Judge のみ Breaker の攻撃シナリオを ≤4 件/バッチに分割した並列裁定で effort high）がレビュー・裁定を担う。**Claude 自身（オーケストレーター）がレビュー・裁定を模擬・代行してはならない**。
 
 いずれのモード・系統でも、返ってきた指摘に対する **採用 / 不採用（過剰対応かどうか）の判定は、レビュイーが行う**（codex 系はオーケストレーター、claude 系は plan-editor エージェント。この不変則はモード・系統によらず変わらない）。
 
@@ -268,7 +268,7 @@ Claude=Breaker × Codex=Judge の二者構造でレビューする。計画に�
 レビュー内容:
 
 - 標準モードは Sonnet（effort max）のレビュワーエージェントが単独で計画をレビューする（観点は codex 標準と同一: 実現可能性・影響範囲の抜け・手順の妥当性・リスクの見落とし・運用/保守/可用性・データ整合性/性能・テストカバレッジ・アーキテクチャ境界・プロジェクト固有基準との整合）
-- 敵対的モードは Breaker（Sonnet / effort max）× Judge（**別の** Sonnet / effort max）の二者構造で、Breaker は上記「敵対的モード（codex 系）」と同じ攻撃観点を用い（反例テストは書かない）、Judge の裁定基準は codex Judge と同等（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準）
+- 敵対的モードは Breaker（Sonnet / effort max）× Judge（**別の** Sonnet / effort high）の二者構造で、Breaker は上記「敵対的モード（codex 系）」と同じ攻撃観点を用い（反例テストは書かない）、Judge は Breaker の攻撃シナリオを ≤4 件/バッチに分割して並列に裁定する（各 Judge の作業量を有界にし無進捗ウォッチドッグへのストールを防ぐ）。Judge の裁定基準は codex Judge と同等（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準）
 - 採用判定・計画修正は plan-editor エージェントが `{作業Dir}/plan.md` を編集して行う。収束後はオーケストレーターが `plan.md` を読んで投稿する
 
 Workflow 返却の扱い（詳細は [references/agent-orchestration.md](references/agent-orchestration.md)）:
@@ -277,6 +277,7 @@ Workflow 返却の扱い（詳細は [references/agent-orchestration.md](referen
 - `converged: false`（3 ラウンド消化）→ 上限チェックの AskUserQuestion。続行なら `startRound` を +3、`priorSummary` に経緯要約を入れて同じ scriptPath で再起動
 - `specQuestions` が空でない → 裁定「仕様未定」の項目をオーケストレーターが AskUserQuestion で確認し、確定内容を `{作業Dir}/context.md`（追加指示）へ追記する。修正が必要になれば未収束として次セットへ回す（`converged: true` で返っていても投稿しない）
 - `auditFailed: true` → セキュリティ監査役の失敗を完了報告に明記する
+- `judgeDegraded: true` → 一部の Judge バッチが失敗し攻撃シナリオが未裁定のまま収束扱いになった旨を完了報告に明記し、`plan.md` 投稿前にユーザーへ確認する
 - `status: 'agent-failed'` → 1 回だけ `resumeFromRunId` で再開、それでも失敗ならフォールバック（claude 系）へ
 
 > claude 系の独立性は**コンテキスト隔離 + 役割分離**で担保する（レビュワー・Breaker・Judge・plan-editor は互いに fresh エージェント）。codex 系のような別系統モデルの独立性はないため、認証・決済・データスキーマ・外部 API 変更などの重要変更には codex 系を推奨する。

--- a/skills/smart-issue-plan/references/agent-orchestration.md
+++ b/skills/smart-issue-plan/references/agent-orchestration.md
@@ -175,20 +175,24 @@ ${prior()}${auditNote}
 - 構造化出力の scenarios に同じ内容を返す。各シナリオに unaddressed（計画のどの手順・前提が対処できていないか）を必ず付す
 制約: 計画・コードを変更しない。コミットしない。`
 
-const judgePrompt = (round, breaker) => `あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した設計への攻撃シナリオを、リポジトリの実コードと計画本文に照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは計画作成にも攻撃シナリオ生成にも関与していない。
+const judgeBatchPrompt = (round, batch, batchNum, batchTotal) => `あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した設計への攻撃シナリオを、リポジトリの実コードと計画本文に照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは計画作成にも攻撃シナリオ生成にも関与していない。これはラウンド ${round} の攻撃シナリオをバッチ分割した ${batchNum}/${batchTotal} 番目のバッチである。
 ## 入力
 1. ${ctx} を読む（Issue 要件・追加指示・プロジェクト固有基準）
 2. ${target}（ラウンド ${round}）
-3. Breaker の攻撃シナリオ（詳細は ${args.workDir}/breaker-round-${round}.md）:
-${JSON.stringify(breaker.scenarios, null, 2)}
+3. このバッチで裁定する攻撃シナリオ（これ以外は扱わない）:
+${JSON.stringify(batch, null, 2)}
 ${prior()}
 ## 裁定タスク
-1. 各シナリオを実コードと計画本文に照合し、次の 4 カテゴリに分類する:
-   - 真の欠陥: 計画が対処すべきなのに手順・前提に欠落・誤りがあり、修正価値がある（仕様違反・セキュリティ・後方互換性・運用 / 保守 / 可用性・データ整合性 / 性能・テストカバレッジ不足・アーキテクチャ逸脱・プロジェクト固有基準違反）
-   - 仕様未定: 要件・仕様が曖昧で、Breaker が勝手な前提を置いている（要仕様確認）
-   - 低優先度: 妥当だが重大度が低く、計画に反映するコストに見合わない
-   - ノイズ: 反証不能・誤解・的外れ、または計画が既に対処済み（除外）
-2. Breaker が見落とした計画の欠陥があれば、独立レビューとして追加で挙げる（同じ 4 カテゴリで分類する）
+各シナリオを実コードと計画本文に照合し、次の 4 カテゴリに分類する:
+- 真の欠陥: 計画が対処すべきなのに手順・前提に欠落・誤りがあり、修正価値がある（仕様違反・セキュリティ・後方互換性・運用 / 保守 / 可用性・データ整合性 / 性能・テストカバレッジ不足・アーキテクチャ逸脱・プロジェクト固有基準違反）
+- 仕様未定: 要件・仕様が曖昧で、Breaker が勝手な前提を置いている（要仕様確認）
+- 低優先度: 妥当だが重大度が低く、計画に反映するコストに見合わない
+- ノイズ: 反証不能・誤解・的外れ、または計画が既に対処済み（除外）
+## 照合の限定（着実に進める）
+- 裁定対象は上記インラインのバッチのシナリオのみ。他バッチのシナリオ・${args.workDir}/breaker-round-${round}.md の他項目は読まない・扱わない
+- 照合は各シナリオの evidence が指すファイル / 行・計画の該当箇所に限定する。evidence が無いシナリオは計画本文とシナリオ本文が名指しする箇所に照合を限定する。いずれの場合も無関係な広域 grep・全サービス横断の探索はしない
+- 3 分以内に着実に tool を進める（一つの探索で止まり続けない）
+- Breaker が見落とした計画の欠陥の独立探索はこのバッチでは行わない（バッチ間の重複を避けるため）
 ## 制約
 - 指摘は計画の欠陥に限定する（文体・体裁・好みは対象外）
 - 「真の欠陥」は次の 4 点に答えられるものだけにする: (1) 実装時に何が起きるか (2) なぜ計画のその手順・前提が脆弱か (3) 想定される影響 (4) 計画をどう直せばリスクが下がるか。答えられない懸念は低優先度またはノイズに分類する
@@ -226,6 +230,7 @@ if (args.securityAudit) {
 
 let converged = false
 let status = 'ok'
+let judgeDegraded = false
 const specQuestions = []
 
 for (let i = 0; i < 3; i++) {
@@ -235,7 +240,17 @@ for (let i = 0; i < 3; i++) {
   if (args.mode === 'adversarial') {
     const breaker = await agent(breakerPrompt(round, auditNote), { label: `breaker:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: BREAK_SCHEMA })
     if (breaker === null) { status = 'agent-failed'; break }
-    findings = await agent(judgePrompt(round, breaker), { label: `judge:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
+    const scen = breaker.scenarios || []
+    const BATCH = 4
+    const batches = []
+    for (let b = 0; b < scen.length; b += BATCH) batches.push(scen.slice(b, b + BATCH))
+    const batchResults = batches.length === 0 ? [] : await parallel(batches.map((batch, bi) => () =>
+      agent(judgeBatchPrompt(round, batch, bi + 1, batches.length),
+        { label: `judge:r${round}-b${bi + 1}`, phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA })))
+    const ok = batchResults.filter(Boolean)
+    if (batches.length > 0 && ok.length === 0) { status = 'agent-failed'; break }
+    if (ok.length < batches.length) { judgeDegraded = true; log(`judge r${round}: ${batches.length - ok.length}/${batches.length} バッチ失敗（部分裁定で続行・未裁定のシナリオあり）`) }
+    findings = { items: ok.flatMap((r) => r.items || []), dismissed: ok.flatMap((r) => r.dismissed || []) }
   } else {
     findings = await agent(reviewerPrompt(round), { label: `reviewer:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
   }
@@ -258,15 +273,16 @@ for (let i = 0; i < 3; i++) {
   if (fix.adopted.length === 0) { converged = true; break }
 }
 
-return { converged, status, records, specQuestions, auditFailed }
+return { converged, status, records, specQuestions, auditFailed, judgeDegraded }
 ```
 
 返却の扱い:
 
-- `converged: true` → まず `specQuestions` が空であることを確認する（非空なら下記の `specQuestions` 処理を先に行い、仕様確定で修正が生じたら未収束として次セットへ回す）。空なら収束確定 → オーケストレーターが `{作業Dir}/plan.md` を読んで投稿する（計画レビューのため最終 QA は回さない）
+- `converged: true` → まず `specQuestions` が空であることを確認する（非空なら下記の `specQuestions` 処理を先に行い、仕様確定で修正が生じたら未収束として次セットへ回す）。空なら収束確定 → オーケストレーターが `{作業Dir}/plan.md` を読んで投稿する（計画レビューのため最終 QA は回さない）。`judgeDegraded: true` のときは未裁定のシナリオが残るため、投稿前にユーザーへ確認する（下記 `judgeDegraded`）
 - `converged: false` かつ `status: 'ok'`（3 ラウンド消化）→ 上限チェック: `records` の残指摘を要約提示して AskUserQuestion（続行 / 打ち切り / 中止）。続行なら `startRound` を +3、`priorSummary` に経緯要約を入れて同じ scriptPath で再起動する。打ち切りなら未収束のまま投稿（表記は「未収束で打ち切り」）
 - `specQuestions` が空でない → 裁定「仕様未定」の項目。オーケストレーターが AskUserQuestion でユーザーに仕様を確認し、確定内容を `{作業Dir}/context.md`（追加指示）へ追記する。修正が必要になった場合は未収束として扱い、次セットで plan-editor が `plan.md` へ反映する
 - `auditFailed: true` → セキュリティ監査役が失敗し、Breaker 内蔵のセキュリティ観点のみで実施された。完了報告に明記する
+- `judgeDegraded: true` → 一部の Judge バッチが失敗し、その攻撃シナリオ（最大 4 件/バッチ）が未裁定のまま収束扱いになった。計画レビューは最終 QA を持たず未裁定の欠陥をバックストップできないため、完了報告に明記し `plan.md` 投稿前にユーザーへ確認する（`auditFailed` と同型の劣化伝播）
 - `status: 'agent-failed'` → 1 回だけ `resumeFromRunId` で再開、それでも失敗なら SKILL.md の「フォールバック（claude 系）」へ
 
 ## 完了報告への反映
@@ -276,6 +292,7 @@ return { converged, status, records, specQuestions, auditFailed }
 - レビューループ: 各ラウンドのモード・指摘数・採用数・不採用理由（`records`）
 - `specQuestions` でユーザーに確認した仕様と、その反映
 - `auditFailed: true` の場合はその旨
+- `judgeDegraded: true` の場合は一部の攻撃シナリオが未裁定である旨（失敗バッチ数はログ参照）
 
 ## 同期ノート
 
@@ -284,6 +301,7 @@ return { converged, status, records, specQuestions, auditFailed }
 - セット制御: `startRound` / `priorSummary` / `records` / `history()` / `prior()` の経緯引き継ぎ
 - 収束判定: レビュー指摘 0 件 → 収束、`category: '仕様未定'` を除いた真の欠陥 0 件 → 収束、採用 0 件 → 収束（3 ラウンド 1 セット）
 - null ガード（各 `agent()` 返却の null 判定と `status: 'agent-failed'`）・`auditFailed` フラグ・`specQuestions` の返却経路・セキュリティ監査役の注入（`securityAudit` / `securityReason`）
+- 敵対モード Judge のバッチ並列化: Breaker 出力を ≤4 件/バッチに分割し `parallel` で並列裁定する（`judgeBatchPrompt` / `effort: 'high'` / evidence 限定照合。全バッチ失敗のみ `agent-failed`、一部失敗は部分裁定で続行し `judgeDegraded` フラグで伝播）。Breaker のフィールド名だけ意図的に異なる（resolve = `counterexamples`、plan = `scenarios`）
 
 同期しないもの（**意図的に異なる**）:
 

--- a/skills/smart-issue-resolve/README.md
+++ b/skills/smart-issue-resolve/README.md
@@ -35,7 +35,7 @@ GitHub Issue ID を受け取り、Issue を読み込んでブランチを作成�
 | 設計役 | opus / max | 計画が無い/粗い場合の設計方針確定 + 実装後の設計整合・保守性・可用性レビュー（兼任） |
 | 開発者 | opus / max | 実装（調査→ベースライン→実装→動作確認）とレビュー指摘の採用判定・修正（レビュイー） |
 | 独立 QA | sonnet / high | 自己申告に依存しないテスト・lint の独立実行、受け入れ基準検証、自動コミット前の最終ゲート |
-| レビュワー / Judge（claude 系）・Breaker（両系統の敵対） | sonnet / max | コンテキスト隔離での diff レビュー / 裁定 / 反例生成（Breaker は codex 敵対モードでも使う） |
+| レビュワー / Judge（claude 系）・Breaker（両系統の敵対） | sonnet / max（claude 敵対 Judge のみ high） | コンテキスト隔離での diff レビュー / 裁定 / 反例生成（Breaker は codex 敵対モードでも使う。claude 敵対 Judge は反例を ≤4 件/バッチに分割し並列裁定） |
 | セキュリティ監査役 | sonnet / max | セキュリティ自動発動時に STRIDE・認可・データフロー観点を敵対的レビューへ注入 |
 | レビュワー / Judge（codex 系） | Codex（別系統モデル） | `codex:rescue` 経由のレビュー・裁定（従来どおり） |
 
@@ -58,7 +58,7 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 - **codex 標準（`-cdxrl`）**: Codex（`codex:rescue` 経由）が単独で diff をレビューする
 - **codex 敵対（`-cdxarl`）**: Breaker（独立 Sonnet エージェント。実装文脈から隔離）× Codex=Judge（真の欠陥かノイズかを裁定）の二者構造。Workflow が使えない環境ではメインセッションが Breaker を代行する（従来動作）
 - **claude 標準（`-cldrl`）**: Sonnet（effort max）のレビュワーエージェントが単独で diff をレビューする。観点は codex 標準と同一
-- **claude 敵対（`-cldarl`）**: Breaker × Judge を**別々の** Sonnet（effort max）エージェントが担う。裁定基準は codex Judge と同等。独立性はコンテキスト隔離 + 役割分離で担保（別系統モデルではないため、認証・決済・データスキーマ・外部 API などの重要変更には codex 系を推奨）
+- **claude 敵対（`-cldarl`）**: Breaker × Judge を**別々の** Sonnet エージェントが担う（Breaker=effort max、Judge=effort high で Breaker の反例を ≤4 件/バッチに分割し並列裁定。単一 Judge が多数シナリオの照合で無進捗ウォッチドッグにストールするのを防ぐ）。裁定基準は codex Judge と同等。独立性はコンテキスト隔離 + 役割分離で担保（別系統モデルではないため、認証・決済・データスキーマ・外部 API などの重要変更には codex 系を推奨）
 - **セキュリティ自動発動**: 認証・個人情報・決済などセキュリティ影響を Issue や変更ファイルから検出したら、フラグ未指定でも敵対的レビューを自動で有効化する（発動理由を明示。Codex 不在なら claude 系で代替）。ただしこの自動発動のみのケースでは**コミット・PR は自動実行せず**、従来の完了案内に切り替える（外部副作用の自動化は明示オプトイン時のみ）
 - claude 系は 1 セット（最大 3 ラウンド）を 1 つの Workflow で実行し、3 ラウンドごとの続行確認はセット間にオーケストレーターが行う（サブエージェントはユーザーに質問できないため）
 - 敵対モードの裁定「仕様未定」（仕様が曖昧で要確認の指摘）は、対話できないエージェントに握り潰させず、オーケストレーターが AskUserQuestion でユーザーに確認して確定内容を context.md に反映する

--- a/skills/smart-issue-resolve/SKILL.md
+++ b/skills/smart-issue-resolve/SKILL.md
@@ -31,7 +31,7 @@ GitHub Issue を起点に、ブランチ作成 → 役割別エージェント�
 | 開発者 | Workflow エージェント | opus / max | 手順 6 の実装フロー。レビュー指摘の採用 / 不採用判定と修正（レビュイー） |
 | 独立 QA | Workflow エージェント | sonnet / high | 開発者の自己申告に依存しないテスト・lint の独立実行と受け入れ基準検証。自動コミット前の最終ゲート |
 | レビュワー（claude 標準） | Workflow エージェント | sonnet / max | diff レビュー（codex 標準と同一観点） |
-| Breaker / Judge（敵対） | Workflow エージェント | sonnet / max | 反例生成（Breaker）と裁定（Judge）。コンテキスト隔離で実装文脈から独立 |
+| Breaker / Judge（敵対） | Workflow エージェント | sonnet / max・high | 反例生成（Breaker・max）と裁定（Judge・high。Breaker の反例を ≤4 件/バッチに分割し並列裁定）。コンテキスト隔離で実装文脈から独立 |
 | セキュリティ監査役 | Workflow エージェント | sonnet / max | セキュリティ自動発動時に STRIDE・認可・データフローの観点を敵対的レビューへ注入 |
 | レビュワー / Judge（codex 系） | codex:rescue | -（別系統モデル） | Codex によるレビュー・裁定（従来どおり） |
 
@@ -210,7 +210,7 @@ degraded 実装（Workflow 不能）の場合は「独立 QA・設計整合レ�
 
 ## レビューループ（codex 系 / claude 系）
 
-`{レビューモード}` が `off` 以外の場合に実施する。目的は**実装文脈から独立したレビュー**。codex 系は別系統モデル（Codex）が、claude 系はコンテキスト隔離した Sonnet エージェント（effort max）がレビュー・裁定を担う。**実装側（オーケストレーター・開発者エージェント）がレビュー・裁定を模擬・代行してはならない**（唯一の例外: codex 敵対モードの degraded 環境における Breaker 代行。裁定者 Judge=Codex の独立性が保たれるため許容する）。
+`{レビューモード}` が `off` 以外の場合に実施する。目的は**実装文脈から独立したレビュー**。codex 系は別系統モデル（Codex）が、claude 系はコンテキスト隔離した Sonnet エージェント（effort max。敵対 Judge のみ Breaker 反例を ≤4 件/バッチに分割した並列裁定で effort high）がレビュー・裁定を担う。**実装側（オーケストレーター・開発者エージェント）がレビュー・裁定を模擬・代行してはならない**（唯一の例外: codex 敵対モードの degraded 環境における Breaker 代行。裁定者 Judge=Codex の独立性が保たれるため許容する）。
 
 いずれのモード・系統でも、返ってきた指摘に対する **採用 / 不採用（過剰対応かどうか）の判定は、レビュイーである開発者エージェントが行う**（degraded 実装時はメインセッション。この不変則はモード・系統によらず変わらない）。
 
@@ -270,7 +270,7 @@ Breaker（独立 Sonnet エージェント）× Codex=Judge の二者構造で�
 
 #### claude 系（--claude-review-loop / --claude-adv-review-loop）
 
-雛形 B（sir-claude-review-set）で実行する。標準モードは Sonnet（effort max）のレビュワーエージェントが単独で diff をレビューする（観点は codex 標準と同一）。敵対的モードは Breaker（Sonnet / effort max）× Judge（**別の** Sonnet / effort max）の二者構造で、裁定基準は codex Judge と同等（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準）。
+雛形 B（sir-claude-review-set）で実行する。標準モードは Sonnet（effort max）のレビュワーエージェントが単独で diff をレビューする（観点は codex 標準と同一）。敵対的モードは Breaker（Sonnet / effort max）× Judge（**別の** Sonnet / effort high）の二者構造で、Judge は Breaker の反例を ≤4 件/バッチに分割して並列に裁定する（各 Judge の作業量を有界にし、単一 Judge が多数シナリオの照合で無進捗ウォッチドッグにストールするのを防ぐ）。裁定基準は codex Judge と同等（4 分類・「4 点に答えられるものだけを真の欠陥とする」防御基準）。
 
 > claude 系の独立性は**コンテキスト隔離 + 役割分離**で担保する（レビュワー・Breaker・Judge は実装文脈を持たない fresh エージェント）。codex 系のような別系統モデルの独立性はないため、認証・決済・データスキーマ・外部 API 変更などの重要変更には codex 系を推奨する。
 
@@ -280,7 +280,7 @@ Breaker（独立 Sonnet エージェント）× Codex=Judge の二者構造で�
 
 `{ループ明示}` = true の場合のみ実施する（セキュリティ自動発動のみで発動した場合は手順 7 に切り替える）。`smart-commit` / `smart-pr` は `disable-model-invocation` のため Skill ツールから自動呼び出しできない。ここではコミット・push を `git` で行い、PR 作成・作成者アサインは GitHub MCP（利用不能時は `gh`）で直接行う。プロジェクトの Git 規約に従う（conventional commit・closing keyword は使わない・作成者を自動アサイン。プロジェクト独自規約があればそれを優先）:
 
-1. **最終 QA ゲート** — 自動コミットの前に独立 QA で最終検証する（claude 系の収束時は雛形 B が内蔵実行。codex 系、および claude 系で打ち切りを選んだ場合は雛形 E を 1 回起動する — 起動前に、変更セットに残った `.breaker-probe.` ファイルを取り除いておく。Workflow 不能な degraded 環境では起動できないため省略し、その旨を完了報告に明記する）。`pass: false` なら自動コミット・PR を**中止**し、QA の指摘を提示してユーザーに相談する
+1. **最終 QA ゲート** — 自動コミットの前に独立 QA で最終検証する（claude 系の収束時は雛形 B が内蔵実行。codex 系、および claude 系で打ち切りを選んだ場合は雛形 E を 1 回起動する — 起動前に、変更セットに残った `.breaker-probe.` ファイルを取り除いておく。Workflow 不能な degraded 環境では起動できないため省略し、その旨を完了報告に明記する）。`pass: false` なら自動コミット・PR を**中止**し、QA の指摘を提示してユーザーに相談する。claude 敵対モードで雛形 B の返却に `judgeDegraded: true` が立っている場合も、未裁定の反例が残るため収束していても自動コミット前にユーザーへ確認する（[references/agent-orchestration.md](references/agent-orchestration.md) の「返却の扱い」参照）
 2. **コミット** — 変更を Issue の作業単位でコミットする。コミット前に `git status` で、反例検証用テスト（`.breaker-probe.` を含むファイル。採用欠陥の回帰テスト化済みのものを除く）や一時成果物が変更セットに混ざっていないか確認する。機密ファイルの混入チェック・pre-commit hook 失敗への対応などの安全系確認は省略しない。`--no-verify` は使わない
 3. **push・PR 作成** — feature ブランチを push し、PR を作成する。作成者を自動アサインし、レビュアー向け補足に次を記載する:
    - codex 標準・収束時: `🤖 Codex レビュー済み（標準, N ラウンド, 最終ラウンド採用指摘 0 件）`

--- a/skills/smart-issue-resolve/references/agent-orchestration.md
+++ b/skills/smart-issue-resolve/references/agent-orchestration.md
@@ -373,20 +373,24 @@ ${prior()}${auditNote}
 - 構造化出力の counterexamples に同じ内容を返す
 制約: 反例テスト以外のコード変更をしない。コミットしない。`
 
-const judgePrompt = (round, breaker) => `あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した反例・攻撃シナリオを、リポジトリの実コードと照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは実装にも反例生成にも関与していない。
+const judgeBatchPrompt = (round, batch, batchNum, batchTotal) => `あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した反例・攻撃シナリオを、リポジトリの実コードと照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは実装にも反例生成にも関与していない。これはラウンド ${round} の反例をバッチ分割した ${batchNum}/${batchTotal} 番目のバッチである。
 ## 入力
 1. ${ctx} を読む（Issue 要件・実装計画・プロジェクト固有基準）
 2. ${diffNote}（ラウンド ${round}）
-3. Breaker の反例リスト（詳細は ${args.workDir}/breaker-round-${round}.md）:
-${JSON.stringify(breaker.counterexamples, null, 2)}
+3. このバッチで裁定する反例（これ以外は扱わない）:
+${JSON.stringify(batch, null, 2)}
 ${prior()}
 ## 裁定タスク
-1. 各反例を実コードと照合し、次の 4 カテゴリに分類する:
-   - 真の欠陥: 仕様違反・セキュリティ・回帰・運用 / 保守 / 可用性・データ整合性 / 性能・テストカバレッジ不足・アーキテクチャ逸脱・プロジェクト固有基準違反として妥当で、修正価値がある
-   - 仕様未定: 仕様が曖昧で、Breaker が勝手な前提を置いている（要仕様確認）
-   - 低優先度: 妥当だが重大度が低く、修正コストに見合わない
-   - ノイズ: 反証不能・誤解・的外れ（除外）
-2. Breaker が見落とした欠陥があれば、独立レビューとして追加で挙げる（同じ 4 カテゴリで分類する）
+各反例を実コードと照合し、次の 4 カテゴリに分類する:
+- 真の欠陥: 仕様違反・セキュリティ・回帰・運用 / 保守 / 可用性・データ整合性 / 性能・テストカバレッジ不足・アーキテクチャ逸脱・プロジェクト固有基準違反として妥当で、修正価値がある
+- 仕様未定: 仕様が曖昧で、Breaker が勝手な前提を置いている（要仕様確認）
+- 低優先度: 妥当だが重大度が低く、修正コストに見合わない
+- ノイズ: 反証不能・誤解・的外れ（除外）
+## 照合の限定（着実に進める）
+- 裁定対象は上記インラインのバッチの反例のみ。他バッチの反例・${args.workDir}/breaker-round-${round}.md の他項目は読まない・扱わない
+- 照合は各反例の evidence が指すファイル / 行に限定する。evidence が無い反例は diff の変更範囲とシナリオ本文が名指しする箇所に照合を限定する。いずれの場合も無関係な広域 grep・全サービス横断の探索はしない
+- 3 分以内に着実に tool を進める（一つの探索で止まり続けない）
+- Breaker が見落とした欠陥の独立探索はこのバッチでは行わない（バッチ間の重複を避けるため）
 ## 制約
 - 可読性・命名・スタイルは対象外
 - 「真の欠陥」は次の 4 点に答えられるものだけにする: (1) 何が起きるか (2) なぜそのコードパスが脆弱か (3) 想定される影響 (4) リスクを下げる具体策。答えられない懸念は低優先度またはノイズに分類する
@@ -434,6 +438,7 @@ if (args.securityAudit) {
 
 let converged = false
 let status = 'ok'
+let judgeDegraded = false
 const specQuestions = []
 
 for (let i = 0; i < 3; i++) {
@@ -443,7 +448,17 @@ for (let i = 0; i < 3; i++) {
   if (args.mode === 'adversarial') {
     const breaker = await agent(breakerPrompt(round, auditNote), { label: `breaker:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: BREAK_SCHEMA })
     if (breaker === null) { status = 'agent-failed'; break }
-    findings = await agent(judgePrompt(round, breaker), { label: `judge:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
+    const scen = breaker.counterexamples || []
+    const BATCH = 4
+    const batches = []
+    for (let b = 0; b < scen.length; b += BATCH) batches.push(scen.slice(b, b + BATCH))
+    const batchResults = batches.length === 0 ? [] : await parallel(batches.map((batch, bi) => () =>
+      agent(judgeBatchPrompt(round, batch, bi + 1, batches.length),
+        { label: `judge:r${round}-b${bi + 1}`, phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA })))
+    const ok = batchResults.filter(Boolean)
+    if (batches.length > 0 && ok.length === 0) { status = 'agent-failed'; break }
+    if (ok.length < batches.length) { judgeDegraded = true; log(`judge r${round}: ${batches.length - ok.length}/${batches.length} バッチ失敗（部分裁定で続行・未裁定の反例あり）`) }
+    findings = { items: ok.flatMap((r) => r.items || []), dismissed: ok.flatMap((r) => r.dismissed || []) }
   } else {
     findings = await agent(reviewerPrompt(round), { label: `reviewer:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
   }
@@ -477,21 +492,22 @@ if (converged) {
   if (finalQa === null) status = 'agent-failed'
 }
 
-return { converged, status, records, finalQa, specQuestions, auditFailed }
+return { converged, status, records, finalQa, specQuestions, auditFailed, judgeDegraded }
 ```
 
 返却の扱い:
 
-- `converged: true` → まず `specQuestions` が空であることを確認する（非空なら下記の `specQuestions` 処理を先に行い、仕様確定で修正が生じたら未収束として次セットへ回す。この経路ではコミットしない）。空なら `finalQa.pass` を確認して「収束後のコミット・PR 作成」へ（`pass: false` なら自動コミットを中止し issues を提示して相談）
+- `converged: true` → まず `specQuestions` が空であることを確認する（非空なら下記の `specQuestions` 処理を先に行い、仕様確定で修正が生じたら未収束として次セットへ回す。この経路ではコミットしない）。空なら `finalQa.pass` を確認して「収束後のコミット・PR 作成」へ（`pass: false` なら自動コミットを中止し issues を提示して相談）。加えて `judgeDegraded: true` のときは未裁定の反例が残るため、収束していても自動コミット前にユーザーへ確認する（下記 `judgeDegraded`）
 - `converged: false` かつ `status: 'ok'`（3 ラウンド消化）→ 上限チェック: `records` の残指摘を要約提示して AskUserQuestion（続行 / 打ち切り / 中止）。続行なら `startRound` を +3、`priorSummary` に経緯要約を入れて同じ scriptPath で再起動
 - `specQuestions` が空でない → 裁定「仕様未定」の項目。オーケストレーターが AskUserQuestion でユーザーに仕様を確認し、確定内容を `{作業Dir}/context.md`（追加指示）へ追記する。修正が必要になった場合は未収束として扱い、次セット（または開発者修正 1 回 + 再収束確認）へ進む
 - `auditFailed: true` → セキュリティ監査役が失敗し、Breaker 内蔵のセキュリティ観点のみで実施された。完了報告に明記する
+- `judgeDegraded: true` → 一部の Judge バッチが失敗し、その反例（最大 4 件/バッチ）が未裁定のまま収束扱いになった。`finalQa` はテスト・受け入れ基準の検証で、敵対レビューが対象とする設計・保守・可用性クラスの未裁定欠陥はバックストップしない。完了報告に明記し、自動コミット前にユーザーへ確認する（`auditFailed` と同型の劣化伝播）
 - `status: 'tests-failing'` → テストが壊れたままなので状況を提示して相談（そのまま次セットへ進まない）
 - `status: 'agent-failed'` → 1 回だけ `resumeFromRunId` で再開、それでも失敗なら「フォールバック」（claude 系）へ。`converged: true` で `finalQa` が取得できなかった場合は、雛形 E を単発起動して最終 QA を補完する（QA 未実施のまま自動コミットしない）
 
-> **同期ノート**: 雛形 B（`sir-claude-review-set`）の構造は `smart-issue-plan/references/agent-orchestration.md` の計画レビューセット雛形（`sip-plan-review-set`）へ移植済み。セット制御（`startRound` / `priorSummary` / `records`）・収束判定・null ガード・`auditFailed` / `specQuestions` の経路を**両者で同期する**（片方の構造を変えたら両方更新すること）。plan 側はレビュー対象が計画テキスト（diff ではない）で、コード検証用の機構（反例テスト・QA / 最終 QA・probe 後始末等）を持たない点が意図的に異なる。
+> **同期ノート**: 雛形 B（`sir-claude-review-set`）の構造は `smart-issue-plan/references/agent-orchestration.md` の計画レビューセット雛形（`sip-plan-review-set`）へ移植済み。セット制御（`startRound` / `priorSummary` / `records`）・収束判定・null ガード・`auditFailed` / `specQuestions` / `judgeDegraded` の経路・敵対モード Judge のバッチ並列化（Breaker 出力を ≤4 件/バッチに分割し `parallel` で並列裁定・`effort: 'high'`・evidence 限定照合・一部バッチ失敗は `judgeDegraded` フラグで伝播）を**両者で同期する**（片方の構造を変えたら両方更新すること）。plan 側はレビュー対象が計画テキスト（diff ではない）で、コード検証用の機構（反例テスト・QA / 最終 QA・probe 後始末等）を持たない点が意図的に異なる。
 >
-> また、雛形 B の `reviewerPrompt` / `breakerPrompt` / `judgePrompt`（レビュー観点・攻撃観点・4 分類裁定基準）と雛形 C（`sir-codex-breaker`）の Breaker プロンプトは、単体スキル `code-reviewer`（`--isolated` の単発隔離レビュー）・`code-reviewer-adversarial`（`--claude-judge` の Breaker×Judge）へも移植済み。観点・裁定基準を変更したら、これら単体スキルの `references/agent-orchestration.md` も同期する。マスターの同期対象一覧は CLAUDE.md「スキル改修時の注意」を参照。
+> また、雛形 B の `reviewerPrompt` / `breakerPrompt` / `judgeBatchPrompt`（レビュー観点・攻撃観点・4 分類裁定基準）と雛形 C（`sir-codex-breaker`）の Breaker プロンプトは、単体スキル `code-reviewer`（`--isolated` の単発隔離レビュー）・`code-reviewer-adversarial`（`--claude-judge` の Breaker×Judge）へも移植済み。観点・裁定基準を変更したら、これら単体スキルの `references/agent-orchestration.md` も同期する（バッチ並列化は resolve/plan 間の構造同期であり、裁定基準を変えないため単体スキルへの同期は不要）。マスターの同期対象一覧は CLAUDE.md「スキル改修時の注意」を参照。
 
 ## 雛形 C: codex 敵対モードの Breaker（sir-codex-breaker）
 


### PR DESCRIPTION
## 概要

claude 系敵対的レビューループの単一 Judge が「多数シナリオ × 無限定な横断照合 × effort max」の集約で、harness の 180 秒/ステップ無進捗ウォッチドッグ（×6 リトライ・skill 側で変更不可）に systematic にストールし Workflow 全体が失敗する問題を修正する。

Issue #88（案 A・実セッション検証済み）のとおり、単一 Judge を **Breaker 出力 ≤4 件/バッチの並列 Judge** に置換し、各バッチの作業量を有界化した。

関連 Issue: #88（closing keyword 不使用の運用のため、マージ後に手動クローズ）

## 変更内容

- **skills/smart-issue-resolve/references/agent-orchestration.md**（雛形 B `sir-claude-review-set`）
  - 単一 Judge 呼び出しを、`breaker.counterexamples` を ≤4 件/バッチに分割し `parallel` で並列裁定するバッチ block へ置換
  - `judgePrompt` → `judgeBatchPrompt`: 裁定対象は当バッチのみ / 照合は各シナリオの `evidence` が指すファイル・行に限定（広域 grep・横断探索禁止）/ 3 分以内の着実な tool 進行を明示 / バッチ版では独立レビューの新規欠陥追加なし / `effort: 'max'` → `'high'`（4 分類裁定基準・防御基準は不変）
  - 部分バッチ失敗の劣化フラグ `judgeDegraded` を追加（`auditFailed` と同型の伝播。収束時も自動コミット前にユーザー確認）
- **skills/smart-issue-plan/references/agent-orchestration.md**（`sip-plan-review-set`）: 同型反映で構造同期を維持（意図的差異は Breaker フィールド名のみ: resolve=`counterexamples` / plan=`scenarios`。`judgeDegraded` 時は `plan.md` 投稿前にユーザー確認）
- **両スキルの SKILL.md / README.md**: Judge の effort（max→high）とバッチ並列構造の記述を実態に合わせて最小更新。resolve SKILL.md の「収束後のコミット・PR 作成」最終 QA ゲートに `judgeDegraded` 時のユーザー確認を明記
- **CLAUDE.md**: マスター同期一覧の resolve エントリ識別子 `judgePrompt` → `judgeBatchPrompt`（1 語）
- **docs/implementation-notes/2026-07-13-issue-88-judge-batch-parallel.md**: 判断事項 9 件・リスク（`parallel` の runtime 契約は静的検査対象外・初回実運用で確認）・フォローアップ候補（`code-reviewer-adversarial` の同型ストールリスクは別 Issue 推奨）

## 受け入れ基準への対応

- **完了条件 1**（Breaker 10 件以上でも Judge がストールせず完走する構造）: バッチ上限 4 件 → ⌈N/4⌉ 並列・evidence 限定照合・effort high で各バッチの作業量を有界化（10 件 → 3 並列、14 件 → 4 並列）
- **完了条件 2**（両テンプレート反映・構造同期）: 両ファイルに同型のバッチ block + `judgeBatchPrompt` を反映し、両同期ノートにバッチ並列化と `judgeDegraded` の伝播を追記

## 検証

- Workflow 雛形の JS 構文チェック（CLAUDE.md 標準手順・`node --check`）: 変更前後とも resolve 5 block / plan 1 block 全 OK（回帰なし）
- `npx skills add ./ --list`: 19 skills 検出継続（frontmatter 非破壊）
- バッチ分割境界（0 / 4 / 5 / 14 件 → 0 / 1 / 2 / 4 バッチ）の数値検証、下流互換（specQuestions 抽出・records 記録・収束判定・standard 分岐が無改修で動くこと）のコードレビュー
- 旧 `judgePrompt` の dead code 残骸なし・args 正規化シム維持・`.breaker-probe.` / ユーザー名入りパスの混入なしを grep で確認

## レビュー

🤖 Claude レビュー済み（標準, Sonnet/effort max, 1 ラウンド, 最終ラウンド採用指摘 0 件）

- レビューループ ラウンド 1: 指摘 1 件 / 採用 0 件（不採用理由: evidence 欠落時のフォールバックは実装済みで、指摘の前提が現行ファイルの記載と不一致）/ dismissed 4 件 → 収束
- 実装フェーズの設計整合レビュー（opus）: 3 指摘 → 3 件採用（`judgeDegraded` の追加・no-throw 契約の文書化・CLAUDE.md 識別子更新）
- 収束時の独立最終 QA: pass（推奨 1 件 = resolve SKILL.md 最終 QA ゲートへの `judgeDegraded` 明記 → 本 PR で反映済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)