### PR TITLE
feat: Workflow レビュー雛形に JST 進捗ログを追加

### DIFF
--- a/docs/implementation-notes/2026-07-17-workflow-jst-progress-logging.md
+++ b/docs/implementation-notes/2026-07-17-workflow-jst-progress-logging.md
@@ -1,0 +1,72 @@
+# 実装ノート: Workflow レビュー雛形への JST 進捗ログ追加
+
+日付: 2026-07-17 (JST)
+
+## 背景・要望
+
+`smart-issue-resolve` / `smart-issue-plan` / `code-reviewer` / `code-reviewer-adversarial` の
+Workflow スクリプト雛形は background 実行される。進捗は `/workflows` で確認できるが、IDE 拡張
+（VSCode 等）では `/workflows` が使えず、ステップがどこまで進んだか・止まっていないかを確認する
+手段がなかった。ユーザー要望: ステップが進行した際に、その時刻（JST hh:mm）付きの進捗メッセージを
+出してほしい。
+
+## 仕様に明記されていなかったため自分で判断した事項
+
+- **Workflow スクリプト本体は時刻を生成できない制約への対応**: Workflow ツールは
+  `Date.now()` / `Math.random()` / 引数なし `new Date()` をスクリプト内で呼ぶとエラーになる
+  （resume の再現性を壊すため）。そのためスクリプト自身は「今の時刻」を取得できない。
+  対応として、各 `agent()` にプロンプト末尾で `TZ=Asia/Tokyo date '+%H:%M'` を実行させ、
+  結果を構造化出力の共通フィールド `nowJst` として返させ、スクリプト側は `agent()` 呼び出し
+  直後にその値で `log(`[HH:MM JST] ...`)` する設計にした（エージェントは実際に Bash を実行する
+  ため非決定性の制約を受けない）。
+- **粒度・対象範囲**: ユーザーに「全 agent() 呼び出し直後」か「既存 log() 箇所のみ」か等の選択肢を
+  提示し、「全 agent() 呼び出し直後」「4 スキル全部」を選択してもらった。これに従い、
+  smart-issue-resolve（雛形 A〜E）・smart-issue-plan（sip-plan-review-set）・
+  code-reviewer（cr-isolated-review）・code-reviewer-adversarial（cra-claude-judge）の
+  すべての `agent()` 呼び出しに `nowJst` を付与した。
+  例外: `dev:probe-cleanup`（`.breaker-probe.` ファイルの後始末。低 effort・戻り値を元々
+  使用していない軽量ステップ）はログ対象から除外した。情報価値が低く、schema 化のための
+  変更コストに見合わないと判断したため。
+- **自由記述（schema なし）エージェントの扱い**: 設計役（雛形 A の `architect:design`）・
+  セキュリティ監査役（雛形 B/C・plan の `security:audit`）・code-reviewer の単発レビュー
+  （`cr-isolated-review`）はもともと schema を使わず自由記述テキストをそのまま返していた。
+  `nowJst` を持たせるため、いずれも軽量な schema（`{ summary, nowJst }` または
+  `{ review, nowJst }`）に変換した。設計役の戻り値は元々 truthy チェックにしか使われておらず
+  実害なし。セキュリティ監査役は戻り値をテンプレート文字列に直接埋め込んでいたため、
+  `audit` → `audit.summary` に呼び出し側を追随させた。code-reviewer は戻り値そのものが
+  ユーザー表示用の 5 区分 markdown だったため、`return { review: result.review }` の形で
+  従来の戻り値契約（`{ review }`。`review` は文字列または agent 失敗時に `null`）を維持した。
+- **バッチ並列処理（敵対モード Judge）の時刻集約**: `sir-claude-review-set` /
+  `sip-plan-review-set` の Judge は `parallel()` で複数バッチに分割実行されるため、単一の
+  完了時刻を持たない。各バッチ結果の `nowJst` のうち最大値（最後に完了したバッチの時刻）を
+  ラウンドの Judge 完了時刻としてログに使う設計にした。
+
+## 変更内容
+
+各雛形ファイルに以下を追加（共通パターン。CLAUDE.md「スキル改修時の注意」の同期対象と重なる
+4 ファイルすべてに同一パターンで適用済み）:
+
+- `NOW_JST_FIELD`（共通スキーマフィールド定義）/ `TIME_NOTE`（プロンプト末尾に足す指示文）の
+  定数をスクリプト冒頭に追加
+- 既存の各スキーマ（`FINDINGS_SCHEMA` / `FIX_SCHEMA` / `QA_SCHEMA` / `IMPL_SCHEMA` /
+  `BREAK_SCHEMA` 等）に `nowJst`（必須）を追加
+- 各エージェントプロンプトの末尾に `${TIME_NOTE}` を追加
+- 各 `agent()` 呼び出し直後（null ガードの後）に `log(`[${result.nowJst} JST] <ステップ名> 完了...`)` を追加
+- 各ファイルの「前提とゲート」節に、この規約（新しい `agent()` 呼び出しを追加する際も従うこと）を明記
+
+## 検証
+
+`bash -n` 相当として、CLAUDE.md「よく使うコマンド」記載の js ブロック抽出 + `node --check` を
+4 ファイルすべてに対して実行し、全ブロックが構文エラー無しであることを確認済み（実行環境:
+`mise exec node -- node --check`）。実際に Workflow ツールでこれらの雛形を起動して
+ログ出力を目視確認するテストは、この変更セッションでは実施していない（未実施。次回
+smart-issue-resolve 等を実際に使う際に確認することを推奨）。
+
+## 補足: 作業ブランチについて
+
+この変更に着手した時点で、作業ツリーは別タスク（Issue #94: edge routing avoidance、
+ブランチ `feature/issue-94-edge-routing-avoidance`）向けの未コミット変更
+（`skills/structure-visualize/assets/diagram-template.html` 等）と、さらに無関係な
+複数の未コミット変更（`CLAUDE.md` / `dotfiles/claude/*` 等、いずれも本セッションでは
+一切編集していない）を抱えた状態だった。今回の JST 進捗ログ追加はこれらと独立した変更のため、
+コミット・ブランチ運用はユーザーに判断を委ねる。

--- a/skills/code-reviewer-adversarial/references/agent-orchestration.md
+++ b/skills/code-reviewer-adversarial/references/agent-orchestration.md
@@ -9,6 +9,7 @@ code-reviewer-adversarial の `--claude-judge` モード（および Codex 不�
 - スクリプトはこの雛形を**そのまま** `script`（または本ファイルから抽出した `scriptPath`）に渡し、可変値はすべて `args` で渡す（スクリプト本文を書き換えない。プロンプト文はスクリプトに内蔵済み）
 - `args` は JSON 値として渡す（文字列化した JSON を渡さない）。ただし呼び出し経路によっては文字列（`typeof args === 'string'`）で着弾する環境があるため、雛形は meta 直後に正規化シム（`args = typeof args === 'string' ? JSON.parse(args) : (args || {})`）を持つ。文字列・オブジェクトどちらで届いても本文のトップレベル `args.` 参照が機能する
 - Workflow スクリプト内では `Date.now()` / `Math.random()` / 引数なし `new Date()` は使えない（雛形は使用していない）
+- **進捗の可視化**: IDE 拡張では `/workflows` の進捗表示が使えないため、`agent()` はプロンプト末尾の指示（`TIME_NOTE`）で `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を構造化出力の `nowJst`（`NOW_JST_FIELD`）として返す。スクリプト側は `agent()` 呼び出し直後にその値で `log(`[HH:MM JST] ...`)` する（スクリプト自身は時刻を生成できないため、必ずエージェントの返り値から取得する）
 - Phase 3（最終出力）・Phase 4（PR 投稿ゲート）はオーケストレーター（メインセッション）が担う。エージェントは裁定結果を返すだけで、投稿・コミットはしない
 - **単発**（ループ・収束判定・上限チェックは持たない）
 
@@ -30,6 +31,9 @@ export const meta = {
 // args は文字列で届く環境があるため正規化する（トップレベルの args. 参照を機能させる防御シム）
 args = typeof args === 'string' ? JSON.parse(args) : (args || {})
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const target = `レビュー対象: ${args.target}。diff の取得: ${args.diffBase}（これに従って変更ファイル・行・hunk を自分で特定する。PR 対象なら GitHub MCP で diff を取得。大きい場合は diff テキストと変更ファイルリストのみ保持する）。`
 const testNote = args.testCmd
   ? `反例テストは ${args.testCmd} で実行して検証する。`
@@ -37,7 +41,7 @@ const testNote = args.testCmd
 
 const BREAK_SCHEMA = {
   type: 'object',
-  required: ['counterexamples'],
+  required: ['counterexamples', 'nowJst'],
   properties: {
     counterexamples: {
       type: 'array',
@@ -52,12 +56,13 @@ const BREAK_SCHEMA = {
         },
       },
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const FINDINGS_SCHEMA = {
   type: 'object',
-  required: ['items'],
+  required: ['items', 'nowJst'],
   properties: {
     items: {
       type: 'array',
@@ -79,6 +84,7 @@ const FINDINGS_SCHEMA = {
       items: { type: 'object', required: ['title', 'category'], properties: { title: { type: 'string' }, category: { type: 'string', enum: ['低優先度', 'ノイズ'] } } },
       description: '採用対象外（監査性のため件数とタイトルのみ残す）',
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -101,9 +107,10 @@ ${args.focus ? `\n## 重点観点（優先的に攻撃する）\n${args.focus}\n
 - 反例テスト以外のコード変更をしない。コミット・push はしない
 - 「良いコード」「可読性」系は出さない（このスキルの対象外）
 - 反証不能な指摘は verified: UNVERIFIED とし、Judge がノイズとして切る前提で確信度を低く扱う
-最終出力: counterexamples に反例リスト（重複統合・カテゴリ分類はしない。それは Judge の役割）。`,
+最終出力: counterexamples に反例リスト（重複統合・カテゴリ分類はしない。それは Judge の役割）。${TIME_NOTE}`,
   { label: 'breaker', phase: 'Break', model: 'sonnet', effort: 'max', schema: BREAK_SCHEMA })
 if (breaker === null) return { status: 'agent-failed', at: 'breaker' }
+log(`[${breaker.nowJst} JST] breaker 完了（反例${breaker.counterexamples.length}件）`)
 
 const findings = await agent(`あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した反例・攻撃シナリオを、リポジトリの実コードと照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは実装にも反例生成にも関与していない。
 ## 入力
@@ -122,9 +129,11 @@ ${JSON.stringify(breaker.counterexamples, null, 2)}
 - 「真の欠陥」は次の 4 点に答えられるものだけにする: (1) 何が起きるか (2) なぜそのコードパスが脆弱か (3) 想定される影響 (4) リスクを下げる具体策。答えられない懸念は低優先度またはノイズに分類する
 - 弱い指摘を複数並べるより、根拠を防御できる強い指摘を優先する
 - コード・ファイルを変更しない（裁定のみ）。コミットしない
-- items には「真の欠陥」「仕様未定」のみを入れ（category を設定し、真の欠陥には fix を付ける）、低優先度・ノイズは dismissed に件数とタイトルだけ残す`,
+- items には「真の欠陥」「仕様未定」のみを入れ（category を設定し、真の欠陥には fix を付ける）、低優先度・ノイズは dismissed に件数とタイトルだけ残す
+${TIME_NOTE}`,
   { label: 'judge', phase: 'Judge', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
 if (findings === null) return { status: 'agent-failed', at: 'judge' }
+log(`[${findings.nowJst} JST] judge 完了（真の欠陥/仕様未定 ${findings.items.length}件）`)
 
 return { status: 'ok', items: findings.items, dismissed: findings.dismissed || [], counterexamples: breaker.counterexamples }
 ```

--- a/skills/code-reviewer/references/agent-orchestration.md
+++ b/skills/code-reviewer/references/agent-orchestration.md
@@ -7,6 +7,7 @@ code-reviewer の `--isolated` モードで起動する、コンテキスト隔�
 - スクリプトはこの雛形を**そのまま** `script`（または本ファイルから抽出した `scriptPath`）に渡し、可変値はすべて `args` で渡す（スクリプト本文を書き換えない。プロンプト文はスクリプトに内蔵済み）
 - `args` は JSON 値として渡す（文字列化した JSON を渡さない）。ただし呼び出し経路によっては文字列（`typeof args === 'string'`）で着弾する環境があるため、雛形は meta 直後に正規化シム（`args = typeof args === 'string' ? JSON.parse(args) : (args || {})`）を持つ。文字列・オブジェクトどちらで届いても本文のトップレベル `args.` 参照が機能する
 - Workflow スクリプト内では `Date.now()` / `Math.random()` / 引数なし `new Date()` は使えない（雛形は使用していない）
+- **進捗の可視化**: IDE 拡張では `/workflows` の進捗表示が使えないため、`agent()` はプロンプト末尾の指示（`TIME_NOTE`）で `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を構造化出力の `nowJst`（`NOW_JST_FIELD`）として返す。スクリプト側は `agent()` 呼び出し直後にその値で `log(`[HH:MM JST] ...`)` する（スクリプト自身は時刻を生成できないため、必ずエージェントの返り値から取得する）
 - レビュー結果の出力（チャット表示）と PR 投稿ゲートはオーケストレーター（メインセッション）が担う。エージェントはレビュー結果（5 区分 markdown）を返すだけで、投稿・コミットはしない
 
 ## 雛形: 単発隔離レビュー（cr-isolated-review）
@@ -24,7 +25,19 @@ export const meta = {
 // args は文字列で届く環境があるため正規化する（トップレベルの args. 参照を機能させる防御シム）
 args = typeof args === 'string' ? JSON.parse(args) : (args || {})
 
-const review = await agent(`あなたは実装コードのレビュワーである。会話・実装の文脈を持たない独立の立場から、仕様整合・設計適合・可読性を担保するレビューを行う。
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['review', 'nowJst'],
+  properties: {
+    review: { type: 'string', description: '5 区分markdown（該当すれば Codex クロスチェック推奨節を含む）' },
+    nowJst: NOW_JST_FIELD,
+  },
+}
+
+const result = await agent(`あなたは実装コードのレビュワーである。会話・実装の文脈を持たない独立の立場から、仕様整合・設計適合・可読性を担保するレビューを行う。
 ## レビュー対象
 - 対象: ${args.target}
 - diff の取得: ${args.diffBase}
@@ -51,10 +64,12 @@ ${args.focus ? `- 重点観点: ${args.focus}\n` : ''}## 観点（6 観点で確
 認証・認可 / 決済・課金 / データスキーマ / 外部 API・依存契約のいずれかに該当する変更が含まれる場合は、5 区分の直後に「### Codex クロスチェック推奨」節（理由: 該当カテゴリ）を追加する。
 ## 制約
 - コード・ファイルを変更しない（レビューのみ）。コミット・push はしない。PR への投稿もしない（呼び出し元が行う）
-最終出力: 上記 5 区分（該当すれば Codex クロスチェック推奨節を含む）の markdown をそのまま返す。`,
-  { label: 'reviewer:isolated', phase: 'Review', model: 'sonnet', effort: 'max' })
+最終出力: review に上記 5 区分（該当すれば Codex クロスチェック推奨節を含む）の markdown をそのまま入れる。${TIME_NOTE}`,
+  { label: 'reviewer:isolated', phase: 'Review', model: 'sonnet', effort: 'max', schema: REVIEW_SCHEMA })
+if (result === null) return { review: null }
+log(`[${result.nowJst} JST] レビュー完了`)
 
-return { review }
+return { review: result.review }
 ```
 
 返却の `review`（5 区分 markdown）をオーケストレーターがチャットに表示し、書き出しモードが有効なら SKILL.md「PR 書き出しモード」のテンプレートに埋めて確認ゲート経由で投稿する。`agent()` が `null` を返した（ユーザーのスキップ / 終端エラー）場合は、1 回だけ `resumeFromRunId` で再開を試み、それでも失敗ならメインセッションでの通常レビュー（SKILL.md 手順 4）に degrade する。

--- a/skills/smart-issue-plan/references/agent-orchestration.md
+++ b/skills/smart-issue-plan/references/agent-orchestration.md
@@ -10,6 +10,7 @@ smart-issue-plan の **claude 系計画レビューループ**を担う役割別
 - スクリプトはこのファイルの雛形を**そのまま** `script` に渡し、可変値はすべて `args` で渡す（スクリプト本文を書き換えない。プロンプト文はスクリプトに内蔵済み）
 - `args` は JSON 値として渡す（文字列化した JSON を渡さない）。ただし呼び出し経路によっては文字列（`typeof args === 'string'`）で着弾する環境があるため、雛形は meta 直後に正規化シム（`args = typeof args === 'string' ? JSON.parse(args) : (args || {})`）を持つ。文字列・オブジェクトどちらで届いても本文のトップレベル `args.` 参照が機能する
 - Workflow スクリプト内では `Date.now()` / `Math.random()` / 引数なし `new Date()` は使えない（雛形は使用していない）
+- **進捗の可視化**: IDE 拡張では `/workflows` の進捗表示が使えないため、各 `agent()` はプロンプト末尾の指示（`TIME_NOTE`）で `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を構造化出力の `nowJst`（共通フィールド。`NOW_JST_FIELD`）として返す。スクリプト側は `agent()` 呼び出し直後にその値で `log(`[HH:MM JST] ...`)` する（スクリプト自身は時刻を生成できないため、必ずエージェントの返り値から取得する）。新しい `agent()` 呼び出しを追加する場合もこの規約に従う
 - ツール結果に返る `scriptPath` を控えておくと、同じ雛形の再起動（レビューセット続行など）は `{scriptPath, args}` で再送できる。中断・失敗からの再開は `resumeFromRunId` を使う
 
 ## 作業ディレクトリと引き継ぎファイル
@@ -69,9 +70,12 @@ const ctx = args.workDir + '/context.md'
 const plan = args.workDir + '/plan.md'
 const target = `レビュー対象は実装計画 ${plan} の本文である。計画が言及するファイル・関数・設定はリポジトリの実コードと照合し、「依拠した前提」の正否も検証する。`
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const FINDINGS_SCHEMA = {
   type: 'object',
-  required: ['items'],
+  required: ['items', 'nowJst'],
   properties: {
     items: {
       type: 'array',
@@ -92,12 +96,13 @@ const FINDINGS_SCHEMA = {
       items: { type: 'object', required: ['title', 'category'], properties: { title: { type: 'string' }, category: { type: 'string', enum: ['低優先度', 'ノイズ'] } } },
       description: '採用対象外（監査性のため件数とタイトルのみ残す）',
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const FIX_SCHEMA = {
   type: 'object',
-  required: ['adopted', 'rejected'],
+  required: ['adopted', 'rejected', 'nowJst'],
   properties: {
     adopted: {
       type: 'array',
@@ -108,12 +113,13 @@ const FIX_SCHEMA = {
       items: { type: 'object', required: ['title', 'reason'], properties: { title: { type: 'string' }, reason: { type: 'string' } } },
     },
     notes: { type: 'string' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const BREAK_SCHEMA = {
   type: 'object',
-  required: ['scenarios'],
+  required: ['scenarios', 'nowJst'],
   properties: {
     scenarios: {
       type: 'array',
@@ -128,6 +134,16 @@ const BREAK_SCHEMA = {
         },
       },
     },
+    nowJst: NOW_JST_FIELD,
+  },
+}
+
+const AUDIT_SCHEMA = {
+  type: 'object',
+  required: ['summary', 'nowJst'],
+  properties: {
+    summary: { type: 'string', description: '攻撃シナリオの要点（15 行以内）' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -155,7 +171,8 @@ ${prior()}
 - 指摘は計画の欠陥に限定する（文体・体裁・好みは対象外）
 - 各指摘に根拠（ファイルパス・行番号など一次情報、または計画の該当箇所）と重大度を付ける
 - 計画・コードを変更しない（レビューのみ）。コミットしない
-- 指摘が無ければ items を空配列にする`
+- 指摘が無ければ items を空配列にする
+${TIME_NOTE}`
 
 const breakerPrompt = (round, auditNote) => `あなたは Breaker である。GitHub Issue #${args.issueNumber} の実装計画を「読む」のではなく「壊す」。設計が耐えるべき具体的な攻撃シナリオ・脅威・欠落コントロールを列挙する。計画の作成には関与していない独立の立場を保ち、デフォルトは懐疑: 正常系（happy path）しか想定していない手順は実在の弱点として扱い、「後で対応する」前提や部分的な対処に信用を与えない。計画にはテスト対象のコードが無いため、反例テストは書かない（攻撃シナリオで指摘する）。
 ## 入力
@@ -173,7 +190,7 @@ ${prior()}${auditNote}
 ## 出力
 - ${args.workDir}/breaker-round-${round}.md に攻撃シナリオのリスト（シナリオ・対処できていない計画の手順 / 前提・根拠）を書く
 - 構造化出力の scenarios に同じ内容を返す。各シナリオに unaddressed（計画のどの手順・前提が対処できていないか）を必ず付す
-制約: 計画・コードを変更しない。コミットしない。`
+制約: 計画・コードを変更しない。コミットしない。${TIME_NOTE}`
 
 const judgeBatchPrompt = (round, batch, batchNum, batchTotal) => `あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した設計への攻撃シナリオを、リポジトリの実コードと計画本文に照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは計画作成にも攻撃シナリオ生成にも関与していない。これはラウンド ${round} の攻撃シナリオをバッチ分割した ${batchNum}/${batchTotal} 番目のバッチである。
 ## 入力
@@ -198,7 +215,8 @@ ${prior()}
 - 「真の欠陥」は次の 4 点に答えられるものだけにする: (1) 実装時に何が起きるか (2) なぜ計画のその手順・前提が脆弱か (3) 想定される影響 (4) 計画をどう直せばリスクが下がるか。答えられない懸念は低優先度またはノイズに分類する
 - 弱い指摘を複数並べるより、根拠を防御できる強い指摘を優先する
 - 計画・コードを変更しない（裁定のみ）。コミットしない
-- items には「真の欠陥」「仕様未定」のみを入れ（category を設定）、低優先度・ノイズは dismissed に件数とタイトルだけ残す`
+- items には「真の欠陥」「仕様未定」のみを入れ（category を設定）、低優先度・ノイズは dismissed に件数とタイトルだけ残す
+${TIME_NOTE}`
 
 const editPrompt = (round, items) => `あなたは GitHub Issue #${args.issueNumber} の実装計画を作成した担当者（レビュイー）である。ラウンド ${round} のレビュー指摘を判定し、計画 ${plan} に反映する:
 ${JSON.stringify(items, null, 2)}
@@ -208,7 +226,7 @@ ${JSON.stringify(items, null, 2)}
    - 不採用: 妥当性がない・オーバーエンジニアリングを招く・Issue のスコープ外（理由を 1 行で記録する。Judge が「真の欠陥」と裁定した指摘でも、対応が過剰になるなら不採用にしてよい）
 3. 採用指摘を ${plan} に反映する（計画本文を編集する。実装コードは変更しない）
 4. 反映後も計画の構成（[assets/plan-template.md](../assets/plan-template.md) 準拠）を保つ
-制約: 実装コードは変更しない。コミット・push はしない。指摘の再解釈・要約による弱体化をしない（判定は採用 / 不採用の分類と理由の明記のみ）。`
+制約: 実装コードは変更しない。コミット・push はしない。指摘の再解釈・要約による弱体化をしない（判定は採用 / 不採用の分類と理由の明記のみ）。${TIME_NOTE}`
 
 let auditNote = ''
 let auditFailed = false
@@ -219,10 +237,11 @@ if (args.securityAudit) {
 3. STRIDE・認証 / 認可・データフロー・秘密情報・PII の観点で、この計画が対処すべき脅威と検証すべき攻撃シナリオを列挙する
 4. ${args.workDir}/security-audit.md に書く
 自動発動の理由: ${args.securityReason}
-制約: リポジトリのコード・計画を変更しない（security-audit.md への書き出しは可）。コミット・push はしない。最終出力: 攻撃シナリオの要点（15 行以内）。`,
-    { label: 'security:audit', phase: 'Audit', model: 'sonnet', effort: 'max' })
+制約: リポジトリのコード・計画を変更しない（security-audit.md への書き出しは可）。コミット・push はしない。最終出力: summary に攻撃シナリオの要点（15 行以内）。${TIME_NOTE}`,
+    { label: 'security:audit', phase: 'Audit', model: 'sonnet', effort: 'max', schema: AUDIT_SCHEMA })
   if (audit) {
-    auditNote = `\n## セキュリティ監査観点（攻撃シナリオに必ず含める）\n${audit}\n詳細: ${args.workDir}/security-audit.md\n`
+    auditNote = `\n## セキュリティ監査観点（攻撃シナリオに必ず含める）\n${audit.summary}\n詳細: ${args.workDir}/security-audit.md\n`
+    log(`[${audit.nowJst} JST] セキュリティ監査 完了`)
   } else {
     auditFailed = true
   }
@@ -235,11 +254,12 @@ const specQuestions = []
 
 for (let i = 0; i < 3; i++) {
   const round = args.startRound + i
-  log(`計画レビューラウンド ${round}（${args.mode}）`)
+  log(`計画レビューラウンド ${round}（${args.mode}）開始`)
   let findings = null
   if (args.mode === 'adversarial') {
     const breaker = await agent(breakerPrompt(round, auditNote), { label: `breaker:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: BREAK_SCHEMA })
     if (breaker === null) { status = 'agent-failed'; break }
+    log(`[${breaker.nowJst} JST] breaker r${round} 完了（シナリオ${breaker.scenarios.length}件）`)
     const scen = breaker.scenarios || []
     const BATCH = 4
     const batches = []
@@ -250,9 +270,12 @@ for (let i = 0; i < 3; i++) {
     const ok = batchResults.filter(Boolean)
     if (batches.length > 0 && ok.length === 0) { status = 'agent-failed'; break }
     if (ok.length < batches.length) { judgeDegraded = true; log(`judge r${round}: ${batches.length - ok.length}/${batches.length} バッチ失敗（部分裁定で続行・未裁定のシナリオあり）`) }
+    const judgeTimes = ok.map((r) => r.nowJst).filter(Boolean).sort()
+    if (judgeTimes.length) log(`[${judgeTimes[judgeTimes.length - 1]} JST] judge r${round} 完了（${ok.length}/${batches.length} バッチ）`)
     findings = { items: ok.flatMap((r) => r.items || []), dismissed: ok.flatMap((r) => r.dismissed || []) }
   } else {
     findings = await agent(reviewerPrompt(round), { label: `reviewer:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
+    if (findings) log(`[${findings.nowJst} JST] reviewer r${round} 完了（指摘${findings.items.length}件）`)
   }
   if (findings === null) { status = 'agent-failed'; break }
   if (findings.items.length === 0) {
@@ -269,6 +292,7 @@ for (let i = 0; i < 3; i++) {
   }
   const fix = await agent(editPrompt(round, trueDefects), { label: `plan-editor:r${round}`, phase: 'Edit', model: 'opus', effort: 'max', schema: FIX_SCHEMA })
   if (fix === null) { status = 'agent-failed'; break }
+  log(`[${fix.nowJst} JST] plan-editor r${round} 完了（採用${fix.adopted.length}件）`)
   records.push({ round, findings: findings.items.length, adopted: fix.adopted.length, rejected: fix.rejected, dismissed: (findings.dismissed || []).length })
   if (fix.adopted.length === 0) { converged = true; break }
 }

--- a/skills/smart-issue-resolve/references/agent-orchestration.md
+++ b/skills/smart-issue-resolve/references/agent-orchestration.md
@@ -8,6 +8,7 @@ smart-issue-resolve の実装・レビューを担う役割別エージェント
 - スクリプトはこのファイルの雛形を**そのまま** `script` に渡し、可変値はすべて `args` で渡す（スクリプト本文を書き換えない。プロンプト文はスクリプトに内蔵済み）
 - `args` は JSON 値として渡す（文字列化した JSON を渡さない）。ただし呼び出し経路によっては文字列（`typeof args === 'string'`）で着弾する環境があるため、各雛形は meta 直後に正規化シム（`args = typeof args === 'string' ? JSON.parse(args) : (args || {})`）を持つ。文字列・オブジェクトどちらで届いても本文のトップレベル `args.` 参照が機能する
 - Workflow スクリプト内では `Date.now()` / `Math.random()` / 引数なし `new Date()` は使えない（雛形は使用していない）
+- **進捗の可視化**: IDE 拡張では `/workflows` の進捗表示が使えないため、各 `agent()` はプロンプト末尾の指示（`TIME_NOTE`）で `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を構造化出力の `nowJst`（共通フィールド。`NOW_JST_FIELD`）として返す。スクリプト側は `agent()` 呼び出し直後にその値で `log(`[HH:MM JST] ...`)` する（スクリプト自身は時刻を生成できないため、必ずエージェントの返り値から取得する）。新しい `agent()` 呼び出しを追加する場合もこの規約に従う
 - ツール結果に返る `scriptPath` を控えておくと、同じ雛形の再起動（レビューセット続行など）は `{scriptPath, args}` で再送できる。中断・失敗からの再開は `resumeFromRunId` を使う
 
 ## 作業ディレクトリと context.md
@@ -74,9 +75,12 @@ args = typeof args === 'string' ? JSON.parse(args) : (args || {})
 const ctx = args.workDir + '/context.md'
 const notes = args.workDir + '/impl-notes.md'
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const FINDINGS_SCHEMA = {
   type: 'object',
-  required: ['items'],
+  required: ['items', 'nowJst'],
   properties: {
     items: {
       type: 'array',
@@ -91,12 +95,13 @@ const FINDINGS_SCHEMA = {
         },
       },
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const FIX_SCHEMA = {
   type: 'object',
-  required: ['adopted', 'rejected', 'testsPassed'],
+  required: ['adopted', 'rejected', 'testsPassed', 'nowJst'],
   properties: {
     adopted: {
       type: 'array',
@@ -108,12 +113,13 @@ const FIX_SCHEMA = {
     },
     testsPassed: { type: 'boolean' },
     notes: { type: 'string' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const QA_SCHEMA = {
   type: 'object',
-  required: ['pass', 'executed', 'issues'],
+  required: ['pass', 'executed', 'issues', 'nowJst'],
   properties: {
     pass: { type: 'boolean' },
     executed: { type: 'string', description: '実行したテスト・lint コマンドと結果要約' },
@@ -121,16 +127,27 @@ const QA_SCHEMA = {
       type: 'array',
       items: { type: 'object', required: ['title', 'detail'], properties: { title: { type: 'string' }, detail: { type: 'string' } } },
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const IMPL_SCHEMA = {
   type: 'object',
-  required: ['changedFiles', 'summary', 'testResults'],
+  required: ['changedFiles', 'summary', 'testResults', 'nowJst'],
   properties: {
     changedFiles: { type: 'array', items: { type: 'string' } },
     summary: { type: 'string' },
     testResults: { type: 'string' },
+    nowJst: NOW_JST_FIELD,
+  },
+}
+
+const DESIGN_SCHEMA = {
+  type: 'object',
+  required: ['summary', 'nowJst'],
+  properties: {
+    summary: { type: 'string', description: 'design.md の要点（10 行以内）' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -141,7 +158,7 @@ const qaPrompt = (extra) => `あなたは独立 QA エージェントである�
 4. Issue の受け入れ基準を 1 件ずつ、コードと実行結果に照らして検証する
 5. ファイル名に .breaker-probe. を含む使い捨てテストが変更セットに残っていれば issues として報告する
 制約: コード・ファイルを変更しない。コミット・push はしない。${extra}
-判定: テストが全て通り受け入れ基準を満たすときのみ pass=true。executed に実行コマンドと結果要約、問題は issues に列挙する。`
+判定: テストが全て通り受け入れ基準を満たすときのみ pass=true。executed に実行コマンドと結果要約、問題は issues に列挙する。${TIME_NOTE}`
 
 log('実装フェーズ開始: Issue #' + args.issueNumber)
 
@@ -152,9 +169,10 @@ if (args.needDesign) {
 2. 関連コードを調査し（エントリポイント・依存グラフ・既存パターン・境界条件）、要件を満たす設計方針を確定する
 3. ${args.workDir}/design.md に次を書く: 方針 / 変更対象ファイル / データ・依存の流れ / リスク / テスト方針 / 未確定事項
 制約: コードは変更しない。コミット・push はしない。判断できない仕様は独断で確定せず「未確定事項」に列挙する。
-最終出力: design.md の要点（10 行以内）。`,
-    { label: 'architect:design', phase: 'Design', model: 'opus', effort: 'max' })
+最終出力: summary に design.md の要点（10 行以内）。${TIME_NOTE}`,
+    { label: 'architect:design', phase: 'Design', model: 'opus', effort: 'max', schema: DESIGN_SCHEMA })
   if (design === null) return { status: 'agent-failed', at: 'design' }
+  log(`[${design.nowJst} JST] Design 完了`)
 }
 
 const impl = await agent(`あなたは GitHub Issue #${args.issueNumber} を実装する開発者である。
@@ -164,12 +182,14 @@ const impl = await agent(`あなたは GitHub Issue #${args.issueNumber} を実�
 4. Issue の要件・受け入れ基準・追加指示に沿って実装する。スコープは Issue 記載内容（と計画・設計の範囲）に限定する
 5. 同じスコープのテストを再実行し、既存テストの壊れがないこと・新規要件を満たすことを確認する
 6. ${notes} に次を書く: 変更ファイル / 要件対応（受け入れ基準ごと） / 自分で判断した事項 / テスト結果（ベースライン比較）
-制約: コミット・push はしない。Issue と無関係な変更を混ぜない。`,
+制約: コミット・push はしない。Issue と無関係な変更を混ぜない。${TIME_NOTE}`,
   { label: 'dev:implement', phase: 'Implement', model: 'opus', effort: 'max', schema: IMPL_SCHEMA })
 if (impl === null) return { status: 'agent-failed', at: 'implement' }
+log(`[${impl.nowJst} JST] Implement 完了`)
 
 let qa = await agent(qaPrompt(''), { label: 'qa:verify', phase: 'QA', model: 'sonnet', effort: 'high', schema: QA_SCHEMA })
 if (qa === null) return { status: 'agent-failed', at: 'qa' }
+log(`[${qa.nowJst} JST] QA 完了（pass=${qa.pass}）`)
 
 let qaFixRounds = 0
 while (!qa.pass && qaFixRounds < 2) {
@@ -180,11 +200,13 @@ ${JSON.stringify(qa.issues, null, 2)}
 2. 指摘を検証して修正する（QA の誤検出と判断した場合は理由を rejected に記録する）
 3. 関連スコープのテストを再実行する
 4. ${notes} を更新する
-制約: コミット・push はしない。`,
+制約: コミット・push はしない。${TIME_NOTE}`,
     { label: 'dev:qa-fix-' + qaFixRounds, phase: 'QA', model: 'opus', effort: 'max', schema: FIX_SCHEMA })
   if (fix === null) return { status: 'agent-failed', at: 'qa-fix' }
+  log(`[${fix.nowJst} JST] QA修正${qaFixRounds}回目 完了（採用${fix.adopted.length}件）`)
   qa = await agent(qaPrompt('前回 QA の指摘への対応後の再検証である。'), { label: 'qa:re-verify-' + qaFixRounds, phase: 'QA', model: 'sonnet', effort: 'high', schema: QA_SCHEMA })
   if (qa === null) return { status: 'agent-failed', at: 'qa' }
+  log(`[${qa.nowJst} JST] QA再検証${qaFixRounds}回目 完了（pass=${qa.pass}）`)
 }
 if (!qa.pass) return { status: 'qa-failed', impl, qa }
 
@@ -195,9 +217,10 @@ const arch = await agent(`あなたは設計役である。実装完了後の変
    - 設計整合: 設計方針・実装計画・既存アーキテクチャ（レイヤー責務・依存方向）からの逸脱
    - 保守性: 過度な結合・テスト容易性の低下・変更波及の広さ・不要な抽象化
    - 可用性・運用: タイムアウト / リトライ欠如・障害時や依存劣化時の挙動・リソース枯渇・可観測性（ログ・メトリクス）の欠落・デプロイ / ロールバックの脆さ
-制約: コードは変更しない。コミット・push はしない。可読性・命名・スタイルは対象外。各指摘に根拠（ファイル・行）と重大度を付ける。指摘が無ければ items を空配列にする。`,
+制約: コードは変更しない。コミット・push はしない。可読性・命名・スタイルは対象外。各指摘に根拠（ファイル・行）と重大度を付ける。指摘が無ければ items を空配列にする。${TIME_NOTE}`,
   { label: 'architect:review', phase: 'ArchReview', model: 'opus', effort: 'max', schema: FINDINGS_SCHEMA })
 if (arch === null) return { status: 'agent-failed', at: 'arch-review' }
+log(`[${arch.nowJst} JST] ArchReview 完了（指摘${arch.items.length}件）`)
 
 let archFix = null
 if (arch.items.length > 0) {
@@ -208,12 +231,14 @@ ${JSON.stringify(arch.items, null, 2)}
    - 不採用: 妥当性がない・オーバーエンジニアリングを招く・Issue のスコープ外（理由を 1 行で記録する）
 2. 採用指摘を修正し、関連スコープのテストを再実行する
 3. ${notes} を更新する
-制約: コミット・push はしない。`,
+制約: コミット・push はしない。${TIME_NOTE}`,
     { label: 'dev:arch-fix', phase: 'ArchReview', model: 'opus', effort: 'max', schema: FIX_SCHEMA })
   if (archFix === null) return { status: 'agent-failed', at: 'arch-fix' }
+  log(`[${archFix.nowJst} JST] ArchFix 完了（採用${archFix.adopted.length}件）`)
   if (archFix.adopted.length > 0) {
     qa = await agent(qaPrompt('設計整合レビュー反映後の再検証である。'), { label: 'qa:post-arch', phase: 'ArchReview', model: 'sonnet', effort: 'high', schema: QA_SCHEMA })
     if (qa === null) return { status: 'agent-failed', at: 'qa' }
+    log(`[${qa.nowJst} JST] QA(post-arch) 完了（pass=${qa.pass}）`)
     if (!qa.pass) return { status: 'qa-failed', impl, qa, archFix }
   }
 }
@@ -249,9 +274,12 @@ const ctx = args.workDir + '/context.md'
 const notes = args.workDir + '/impl-notes.md'
 const diffNote = `レビュー対象は現在ブランチ ${args.branch} の変更全体（git diff origin/${args.defaultBranch}...HEAD と、git status / git diff で見える未コミット変更）。ローカル ${args.defaultBranch} は origin より古いことがあるため、必ず origin/${args.defaultBranch} を基準にする。`
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const FINDINGS_SCHEMA = {
   type: 'object',
-  required: ['items'],
+  required: ['items', 'nowJst'],
   properties: {
     items: {
       type: 'array',
@@ -272,12 +300,13 @@ const FINDINGS_SCHEMA = {
       items: { type: 'object', required: ['title', 'category'], properties: { title: { type: 'string' }, category: { type: 'string', enum: ['低優先度', 'ノイズ'] } } },
       description: '採用対象外（監査性のため件数とタイトルのみ残す）',
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const FIX_SCHEMA = {
   type: 'object',
-  required: ['adopted', 'rejected', 'testsPassed'],
+  required: ['adopted', 'rejected', 'testsPassed', 'nowJst'],
   properties: {
     adopted: {
       type: 'array',
@@ -289,12 +318,13 @@ const FIX_SCHEMA = {
     },
     testsPassed: { type: 'boolean' },
     notes: { type: 'string' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const QA_SCHEMA = {
   type: 'object',
-  required: ['pass', 'executed', 'issues'],
+  required: ['pass', 'executed', 'issues', 'nowJst'],
   properties: {
     pass: { type: 'boolean' },
     executed: { type: 'string' },
@@ -302,12 +332,13 @@ const QA_SCHEMA = {
       type: 'array',
       items: { type: 'object', required: ['title', 'detail'], properties: { title: { type: 'string' }, detail: { type: 'string' } } },
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
 const BREAK_SCHEMA = {
   type: 'object',
-  required: ['counterexamples'],
+  required: ['counterexamples', 'nowJst'],
   properties: {
     counterexamples: {
       type: 'array',
@@ -322,6 +353,16 @@ const BREAK_SCHEMA = {
         },
       },
     },
+    nowJst: NOW_JST_FIELD,
+  },
+}
+
+const AUDIT_SCHEMA = {
+  type: 'object',
+  required: ['summary', 'nowJst'],
+  properties: {
+    summary: { type: 'string', description: '攻撃シナリオの要点（15 行以内）' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -349,7 +390,8 @@ ${prior()}
 - 可読性・命名・スタイルは対象外（修正価値のある欠陥のみ）
 - 各指摘に根拠（ファイルパス・行番号など一次情報）と重大度を付ける
 - コード・ファイルを変更しない（レビューのみ）。コミットしない
-- 指摘が無ければ items を空配列にする`
+- 指摘が無ければ items を空配列にする
+${TIME_NOTE}`
 
 const breakerPrompt = (round, auditNote) => `あなたは Breaker である。GitHub Issue #${args.issueNumber} 対応の実装を「読む」のではなく「壊す」。反例・攻撃シナリオ・不変条件違反を列挙する。実装には関与していない独立の立場を保ち、デフォルトは懐疑: 正常系でしか成立しない実装は実在の弱点として扱い、善意・部分的な修正・「後続対応の見込み」に信用を与えない。
 ## 入力
@@ -371,7 +413,7 @@ ${prior()}${auditNote}
 ## 出力
 - ${args.workDir}/breaker-round-${round}.md に反例リスト（シナリオ・根拠・テスト実行結果）を書く
 - 構造化出力の counterexamples に同じ内容を返す
-制約: 反例テスト以外のコード変更をしない。コミットしない。`
+制約: 反例テスト以外のコード変更をしない。コミットしない。${TIME_NOTE}`
 
 const judgeBatchPrompt = (round, batch, batchNum, batchTotal) => `あなたは Judge（裁定者）である。別のエージェント（Breaker）が生成した反例・攻撃シナリオを、リポジトリの実コードと照合して裁定する。Breaker に迎合せず、独立した視点で判断する。あなたは実装にも反例生成にも関与していない。これはラウンド ${round} の反例をバッチ分割した ${batchNum}/${batchTotal} 番目のバッチである。
 ## 入力
@@ -396,7 +438,8 @@ ${prior()}
 - 「真の欠陥」は次の 4 点に答えられるものだけにする: (1) 何が起きるか (2) なぜそのコードパスが脆弱か (3) 想定される影響 (4) リスクを下げる具体策。答えられない懸念は低優先度またはノイズに分類する
 - 弱い指摘を複数並べるより、根拠を防御できる強い指摘を優先する
 - コード・ファイルを変更しない（裁定のみ）。コミットしない
-- items には「真の欠陥」「仕様未定」のみを入れ（category を設定）、低優先度・ノイズは dismissed に件数とタイトルだけ残す`
+- items には「真の欠陥」「仕様未定」のみを入れ（category を設定）、低優先度・ノイズは dismissed に件数とタイトルだけ残す
+${TIME_NOTE}`
 
 const fixPrompt = (round, items) => `あなたは GitHub Issue #${args.issueNumber} を実装した開発者（レビュイー）である。ラウンド ${round} のレビュー指摘を判定・反映する:
 ${JSON.stringify(items, null, 2)}
@@ -407,7 +450,7 @@ ${JSON.stringify(items, null, 2)}
 3. 採用指摘を修正し、関連スコープのテストを再実行する（壊れたまま終えない）
 4. .breaker-probe. を含む反例テストを整理する: 採用した欠陥に対応するものは正規の回帰テストへ変換（リネーム・配置換え）し、それ以外は削除する
 5. ${notes} を更新する
-制約: コミット・push はしない。指摘の再解釈・要約による弱体化をしない（判定は採用 / 不採用の分類と理由の明記のみ）。`
+制約: コミット・push はしない。指摘の再解釈・要約による弱体化をしない（判定は採用 / 不採用の分類と理由の明記のみ）。${TIME_NOTE}`
 
 const qaPrompt = () => `あなたは独立 QA エージェントである。レビューループ収束後・コミット前の最終検証を行う。
 1. ${ctx} を読む（テスト方針・受け入れ基準・diff 基準）
@@ -416,7 +459,7 @@ const qaPrompt = () => `あなたは独立 QA エージェントである。レ�
 4. Issue の受け入れ基準を 1 件ずつ検証する
 5. .breaker-probe. を含むファイルが変更セットに残っていれば issues として報告する
 制約: コード・ファイルを変更しない。コミットしない。
-判定: テストが全て通り受け入れ基準を満たすときのみ pass=true。`
+判定: テストが全て通り受け入れ基準を満たすときのみ pass=true。${TIME_NOTE}`
 
 let auditNote = ''
 let auditFailed = false
@@ -427,10 +470,11 @@ if (args.securityAudit) {
 3. STRIDE・認証 / 認可・データフロー・秘密情報・PII の観点で、この変更に対する脅威と検証すべき攻撃シナリオを列挙する
 4. ${args.workDir}/security-audit.md に書く
 自動発動の理由: ${args.securityReason}
-制約: リポジトリのコード（ソースファイル）を変更しない（security-audit.md への書き出しは可）。コミット・push はしない。最終出力: 攻撃シナリオの要点（15 行以内）。`,
-    { label: 'security:audit', phase: 'Audit', model: 'sonnet', effort: 'max' })
+制約: リポジトリのコード（ソースファイル）を変更しない（security-audit.md への書き出しは可）。コミット・push はしない。最終出力: summary に攻撃シナリオの要点（15 行以内）。${TIME_NOTE}`,
+    { label: 'security:audit', phase: 'Audit', model: 'sonnet', effort: 'max', schema: AUDIT_SCHEMA })
   if (audit) {
-    auditNote = `\n## セキュリティ監査観点（攻撃シナリオに必ず含める）\n${audit}\n詳細: ${args.workDir}/security-audit.md\n`
+    auditNote = `\n## セキュリティ監査観点（攻撃シナリオに必ず含める）\n${audit.summary}\n詳細: ${args.workDir}/security-audit.md\n`
+    log(`[${audit.nowJst} JST] セキュリティ監査 完了`)
   } else {
     auditFailed = true
   }
@@ -443,11 +487,12 @@ const specQuestions = []
 
 for (let i = 0; i < 3; i++) {
   const round = args.startRound + i
-  log(`レビューラウンド ${round}（${args.mode}）`)
+  log(`レビューラウンド ${round}（${args.mode}）開始`)
   let findings = null
   if (args.mode === 'adversarial') {
     const breaker = await agent(breakerPrompt(round, auditNote), { label: `breaker:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: BREAK_SCHEMA })
     if (breaker === null) { status = 'agent-failed'; break }
+    log(`[${breaker.nowJst} JST] breaker r${round} 完了（反例${breaker.counterexamples.length}件）`)
     const scen = breaker.counterexamples || []
     const BATCH = 4
     const batches = []
@@ -458,9 +503,12 @@ for (let i = 0; i < 3; i++) {
     const ok = batchResults.filter(Boolean)
     if (batches.length > 0 && ok.length === 0) { status = 'agent-failed'; break }
     if (ok.length < batches.length) { judgeDegraded = true; log(`judge r${round}: ${batches.length - ok.length}/${batches.length} バッチ失敗（部分裁定で続行・未裁定の反例あり）`) }
+    const judgeTimes = ok.map((r) => r.nowJst).filter(Boolean).sort()
+    if (judgeTimes.length) log(`[${judgeTimes[judgeTimes.length - 1]} JST] judge r${round} 完了（${ok.length}/${batches.length} バッチ）`)
     findings = { items: ok.flatMap((r) => r.items || []), dismissed: ok.flatMap((r) => r.dismissed || []) }
   } else {
     findings = await agent(reviewerPrompt(round), { label: `reviewer:r${round}`, phase: 'Review', model: 'sonnet', effort: 'max', schema: FINDINGS_SCHEMA })
+    if (findings) log(`[${findings.nowJst} JST] reviewer r${round} 完了（指摘${findings.items.length}件）`)
   }
   if (findings === null) { status = 'agent-failed'; break }
   if (findings.items.length === 0) {
@@ -477,6 +525,7 @@ for (let i = 0; i < 3; i++) {
   }
   const fix = await agent(fixPrompt(round, trueDefects), { label: `dev:fix-r${round}`, phase: 'Fix', model: 'opus', effort: 'max', schema: FIX_SCHEMA })
   if (fix === null) { status = 'agent-failed'; break }
+  log(`[${fix.nowJst} JST] dev fix r${round} 完了（採用${fix.adopted.length}件）`)
   records.push({ round, findings: findings.items.length, adopted: fix.adopted.length, rejected: fix.rejected, dismissed: (findings.dismissed || []).length })
   if (!fix.testsPassed) { status = 'tests-failing'; break }
   if (fix.adopted.length === 0) { converged = true; break }
@@ -489,7 +538,7 @@ if (converged) {
       { label: 'dev:probe-cleanup', phase: 'FinalQA', model: 'sonnet', effort: 'low' })
   }
   finalQa = await agent(qaPrompt(), { label: 'qa:final', phase: 'FinalQA', model: 'sonnet', effort: 'high', schema: QA_SCHEMA })
-  if (finalQa === null) status = 'agent-failed'
+  if (finalQa === null) { status = 'agent-failed' } else { log(`[${finalQa.nowJst} JST] FinalQA 完了（pass=${finalQa.pass}）`) }
 }
 
 return { converged, status, records, finalQa, specQuestions, auditFailed, judgeDegraded }
@@ -531,9 +580,12 @@ args = typeof args === 'string' ? JSON.parse(args) : (args || {})
 const ctx = args.workDir + '/context.md'
 const diffNote = `レビュー対象は現在ブランチ ${args.branch} の変更全体（git diff origin/${args.defaultBranch}...HEAD と、git status / git diff で見える未コミット変更）。ローカル ${args.defaultBranch} は origin より古いことがあるため、必ず origin/${args.defaultBranch} を基準にする。`
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const BREAK_SCHEMA = {
   type: 'object',
-  required: ['counterexamples'],
+  required: ['counterexamples', 'nowJst'],
   properties: {
     counterexamples: {
       type: 'array',
@@ -548,6 +600,16 @@ const BREAK_SCHEMA = {
         },
       },
     },
+    nowJst: NOW_JST_FIELD,
+  },
+}
+
+const AUDIT_SCHEMA = {
+  type: 'object',
+  required: ['summary', 'nowJst'],
+  properties: {
+    summary: { type: 'string', description: '攻撃シナリオの要点（15 行以内）' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -560,10 +622,11 @@ if (args.securityAudit) {
 3. STRIDE・認証 / 認可・データフロー・秘密情報・PII の観点で、この変更に対する脅威と検証すべき攻撃シナリオを列挙する
 4. ${args.workDir}/security-audit.md に書く
 自動発動の理由: ${args.securityReason}
-制約: リポジトリのコード（ソースファイル）を変更しない（security-audit.md への書き出しは可）。コミット・push はしない。最終出力: 攻撃シナリオの要点（15 行以内）。`,
-    { label: 'security:audit', phase: 'Audit', model: 'sonnet', effort: 'max' })
+制約: リポジトリのコード（ソースファイル）を変更しない（security-audit.md への書き出しは可）。コミット・push はしない。最終出力: summary に攻撃シナリオの要点（15 行以内）。${TIME_NOTE}`,
+    { label: 'security:audit', phase: 'Audit', model: 'sonnet', effort: 'max', schema: AUDIT_SCHEMA })
   if (audit) {
-    auditNote = `\n## セキュリティ監査観点（攻撃シナリオに必ず含める）\n${audit}\n詳細: ${args.workDir}/security-audit.md\n`
+    auditNote = `\n## セキュリティ監査観点（攻撃シナリオに必ず含める）\n${audit.summary}\n詳細: ${args.workDir}/security-audit.md\n`
+    log(`[${audit.nowJst} JST] セキュリティ監査 完了`)
   } else {
     auditFailed = true
   }
@@ -589,9 +652,10 @@ ${args.priorSummary ? `\n## 前ラウンドまでの経緯\n${args.priorSummary}
 ## 出力
 - ${args.workDir}/breaker-round-${args.round}.md に反例リスト（シナリオ・根拠・テスト実行結果）を書く
 - 構造化出力の counterexamples に同じ内容を返す
-制約: 反例テスト以外のコード変更をしない。コミットしない。`,
+制約: 反例テスト以外のコード変更をしない。コミットしない。${TIME_NOTE}`,
   { label: 'breaker:r' + args.round, phase: 'Break', model: 'sonnet', effort: 'max', schema: BREAK_SCHEMA })
 if (breaker === null) return { status: 'agent-failed' }
+log(`[${breaker.nowJst} JST] breaker r${args.round} 完了（反例${breaker.counterexamples.length}件）`)
 
 return { status: 'ok', counterexamples: breaker.counterexamples, breakerFile: args.workDir + '/breaker-round-' + args.round + '.md', auditFailed }
 ```
@@ -617,9 +681,12 @@ args = typeof args === 'string' ? JSON.parse(args) : (args || {})
 const ctx = args.workDir + '/context.md'
 const notes = args.workDir + '/impl-notes.md'
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const FIX_SCHEMA = {
   type: 'object',
-  required: ['adopted', 'rejected', 'testsPassed'],
+  required: ['adopted', 'rejected', 'testsPassed', 'nowJst'],
   properties: {
     adopted: {
       type: 'array',
@@ -631,6 +698,7 @@ const FIX_SCHEMA = {
     },
     testsPassed: { type: 'boolean' },
     notes: { type: 'string' },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -642,9 +710,10 @@ const fix = await agent(`あなたは GitHub Issue #${args.issueNumber} を実�
 3. 採用指摘を修正し、context.md のテスト方針に従って関連スコープのテストを再実行する（壊れたまま終えない）
 4. .breaker-probe. を含む反例テストを整理する: 採用した欠陥に対応するものは正規の回帰テストへ変換し、それ以外は削除する
 5. ${notes} を更新する
-制約: コミット・push はしない。指摘の再解釈・要約による弱体化をしない（判定は採用 / 不採用の分類と理由の明記のみ）。`,
+制約: コミット・push はしない。指摘の再解釈・要約による弱体化をしない（判定は採用 / 不採用の分類と理由の明記のみ）。${TIME_NOTE}`,
   { label: 'dev:fix-r' + args.round, phase: 'Fix', model: 'opus', effort: 'max', schema: FIX_SCHEMA })
 if (fix === null) return { status: 'agent-failed' }
+log(`[${fix.nowJst} JST] dev fix r${args.round} 完了（採用${fix.adopted.length}件）`)
 
 return { status: 'ok', fix }
 ```
@@ -667,9 +736,12 @@ args = typeof args === 'string' ? JSON.parse(args) : (args || {})
 
 const ctx = args.workDir + '/context.md'
 
+const NOW_JST_FIELD = { type: 'string', description: '完了時刻(JST)。`TZ=Asia/Tokyo date \'+%H:%M\'` の出力をそのまま入れる' }
+const TIME_NOTE = "最後に `TZ=Asia/Tokyo date '+%H:%M'` を実行し、結果を nowJst に入れる。"
+
 const QA_SCHEMA = {
   type: 'object',
-  required: ['pass', 'executed', 'issues'],
+  required: ['pass', 'executed', 'issues', 'nowJst'],
   properties: {
     pass: { type: 'boolean' },
     executed: { type: 'string' },
@@ -677,6 +749,7 @@ const QA_SCHEMA = {
       type: 'array',
       items: { type: 'object', required: ['title', 'detail'], properties: { title: { type: 'string' }, detail: { type: 'string' } } },
     },
+    nowJst: NOW_JST_FIELD,
   },
 }
 
@@ -687,9 +760,10 @@ const qa = await agent(`あなたは独立 QA エージェントである。レ�
 4. Issue #${args.issueNumber} の受け入れ基準を 1 件ずつ、コードと実行結果に照らして検証する
 5. .breaker-probe. を含むファイルが変更セットに残っていれば issues として報告する
 制約: コード・ファイルを変更しない。コミット・push はしない。
-判定: テストが全て通り受け入れ基準を満たすときのみ pass=true。`,
+判定: テストが全て通り受け入れ基準を満たすときのみ pass=true。${TIME_NOTE}`,
   { label: 'qa:final', phase: 'FinalQA', model: 'sonnet', effort: 'high', schema: QA_SCHEMA })
 if (qa === null) return { status: 'agent-failed' }
+log(`[${qa.nowJst} JST] FinalQA 完了（pass=${qa.pass}）`)
 
 return { status: 'ok', qa }
 ```


### PR DESCRIPTION
## Summary
- `smart-issue-resolve`（雛形 A〜E）・`smart-issue-plan`（計画レビューセット雛形）・`code-reviewer`（--isolated 雛形）・`code-reviewer-adversarial`（claude-judge 雛形）の Workflow スクリプトに、JST タイムスタンプ付き進捗ログを追加
- IDE 拡張では `/workflows` の進捗表示が使えないため、background 実行されるレビュー Workflow の進行状況をチャット上の `log()` メッセージで確認できるようにした
- Workflow スクリプト本体は `Date.now()` 等の時刻取得APIを呼べない制約があるため、各 `agent()` にプロンプト末尾で `TZ=Asia/Tokyo date '+%H:%M'` を実行させ、構造化出力の `nowJst` として返させる設計にした（詳細・判断事項は `docs/implementation-notes/2026-07-17-workflow-jst-progress-logging.md` 参照）

## Test plan
- [x] 4 ファイルすべての js ブロックを `node --check` で構文検証（CLAUDE.md 記載の抽出コマンドを使用）
- [ ] 実際に Workflow ツールで各雛形を起動し、ログ出力を目視確認（未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)