### PR TITLE
chore(global-config): ミラーのサニタイズ機構を追加しグローバル設定を取り込む

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Claude Code / Codex / Cursor / Gemini など各種エージェント用のスキ
 ## 記述ルール
 
 - ファイルパスにユーザー名を含めない。ホームディレクトリは `/Users/<name>/` ではなく `~/` で表記する（SKILL.md・コメント・ドキュメント・コミットメッセージ・PR 本文のいずれも同様）
+- **本リポジトリは public**。`dotfiles/claude/`（`~/.claude/` のミラー）に社内・非公開の情報（社内プロキシのホスト名、非公開リポジトリのパス、社内 plugin marketplace 名など）を入れない。ミラーを手で編集するときも同じ。`global-config-pull` はパス正規化・非公開 marketplace のサニタイズ・秘密情報チェックでこれを担保する（除外対象の marketplace 名はリポジトリに書かず、ローカル限定の `~/.claude/.config-sync-exclude` に置く）
 - 実装ノートは `docs/implementation-notes/YYYY-MM-DD-<タスクスラグ>.md` に作成し、変更と同じ PR でコミットする。ルート直下に `implementation-notes.md` を残さない（誤コミット防止のため .gitignore で除外済み）
 - 設計スペックは `docs/specs/YYYY-MM-DD-<タスクスラグ>-design.md` にコミットする。`docs/superpowers/`（brainstorming / writing-plans の作業成果物置き場）は gitignore 対象のため恒久ドキュメントを置かない
 

--- a/docs/implementation-notes/2026-07-21-global-config-sanitize.md
+++ b/docs/implementation-notes/2026-07-21-global-config-sanitize.md
@@ -1,0 +1,31 @@
+# グローバル設定ミラーのサニタイズ（global-config-pull / push）
+
+対象: `internal/global-config-pull/SKILL.md`・`internal/global-config-push/SKILL.md`・`dotfiles/claude/settings.json`・`CLAUDE.md`
+
+## 背景
+
+`/global-config-pull` の実行中に、public リポジトリのミラー `dotfiles/claude/` へ社内情報が入ることが判明した。
+
+- **未公開だったもの（今回コミット前に検出・除去）**: `~/.claude/CLAUDE.md` に別セッションが追記した企業プロキシの節に、社内テナントの MITM CA ホスト名が含まれていた
+- **すでに公開済みだったもの**: `dotfiles/claude/settings.json` の `enabledPlugins` 19 エントリと `extraKnownMarketplaces` 2 件に、社内 GitHub org・**非公開リポジトリのパス 2 件**・社内 plugin 名が含まれていた（既存コミットに存在）
+
+## 自分で判断した事項
+
+- **CLAUDE.md 側は「一般化」で対応**: 実ホスト名を除去し、確認手段（`security find-certificate ... | openssl x509 -noout -subject`）を書く形にした。手順の実用性を保ちつつ企業特定情報を消せ、push で逆流しても矛盾しない。製品名（Netskope）は残した — 回避策が MITM 型プロキシ固有で、診断上の価値があり、企業を特定しないため
+- **settings.json 側は「サニタイズ + マージ」**: ミラーから非公開 marketplace のエントリを除去し、push 時に live 側の該当エントリを復元する。単純にミラーを書き換えるだけだと、push が平文コピーのため偽の値が live に書き戻りプラグイン設定が壊れる
+- **除外対象の marketplace 名はリポジトリに置かない**: 名前自体が社内情報なので、ローカル限定の `~/.claude/.config-sync-exclude`（同期対象外）に列挙し、両スキルがそれを読む。ファイルが無い環境ではサニタイズをスキップして従来動作にフォールバックする
+- **settings.json を同期対象から外す案は採らなかった**: permissions・hooks・statusLine 等の追跡価値が大きく、失うものが大きい。サニタイズで消えるのは非公開 marketplace 由来の 19/33 エントリのみで、残りは従来どおり追跡される
+- **`~` の逆正規化を push に追加**: pull が `$HOME` → `~` に正規化する一方 push は平文コピーだったため、push すると `permissions.additionalDirectories` に `~/...` リテラルが書き戻る既存欠陥があった（live は現在すべて絶対パス）。settings.json の反映経路を書き換えるついでに `sed` で展開するようにした
+- **`jq` 不在環境では settings.json を反映しない**: 単純コピーで代替するとサニタイズ済みミラーがそのまま live を潰すため、飛ばして報告する方が安全
+- **`~/.claude/chrome/` は除外リストへ**: Claude in Chrome の native host wrapper で、CLI が自動生成しマシン固有の絶対パスと CLI バージョンを埋め込む生成物のため
+- **`effortLevel` の記述は値を書かない形に直した**: グローバル CLAUDE.md に「（現在 "max"）」と実値が書かれていたが、実際は `xhigh` でドリフトしていた。`xhigh` に書き換えると同じ陳腐化を繰り返すため、値を書かず確認コマンド（`jq -r .effortLevel ~/.claude/settings.json`）を示す形にした
+
+## 検証
+
+- 両 SKILL.md の bash ブロックを抽出して `bash -n`: pull 6 ブロック・push 5 ブロックすべて PASS
+- サニタイズ実行後のミラー: `zozo|st-tech|goskope|near-fashion` の grep 0 件、`jq -e .` PASS、`enabledPlugins` 33 → 14 件
+- push マージを live へ書かず一時ファイルで実行し、`jq -S` 正規化して live と `diff`: **完全一致**（`enabledPlugins` 33 件・`extraKnownMarketplaces` 7 件が復元、`~` リテラル 0 件）
+
+## 残課題
+
+- 既存コミットの履歴には社内 org・非公開リポジトリのパスが残る。除去には履歴書き換えが必要だが、本リポジトリは git tree-SHA ベースで配布（`npx skills` の `#v<X.Y.Z>` pin）しており、書き換えると配布済み pin が壊れるうえ force push はプロジェクト規約で禁止のため実施していない。HEAD からの除去と今後の流入停止に留める（ユーザー判断で許容済み）

--- a/dotfiles/claude/CLAUDE.md
+++ b/dotfiles/claude/CLAUDE.md
@@ -14,11 +14,16 @@
 
 ## 検証強制 Hook / 思考深度
 - Stop hook `~/.claude/hooks/verify-before-claim.sh`（settings.json の hooks.Stop に登録済み）が「コード編集後、検証コマンドの実行記録なしに完了・修正済みを主張して終了する」ターンを差し戻す。差し戻されたら検証を実行するか「未検証」と明記して報告し直すこと（強制は 1 stop につき 1 回のみ。モデル問わず有効）
-- 思考深度は settings.json の `effortLevel`（現在 "max"）で制御する。現行モデル（Fable 5 / Sonnet 5 / Opus 4.7 以降）は adaptive reasoning のため `MAX_THINKING_TOKENS` は効かない（旧世代モデルの固定 thinking budget 専用。CLI v2.1.111 以降で確認済み）
+- 思考深度は settings.json の `effortLevel` で制御する（現在値は `jq -r .effortLevel ~/.claude/settings.json` で確認する。ここに値を書くと設定変更で陳腐化するため書かない）。現行モデル（Fable 5 / Sonnet 5 / Opus 4.7 以降）は adaptive reasoning のため `MAX_THINKING_TOKENS` は効かない（旧世代モデルの固定 thinking budget 専用。CLI v2.1.111 以降で確認済み）
 
 ## Time Display
+- **現在時刻を出力する前に必ず `TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M'` を実行し、その出力をそのまま使うこと**。記憶・推測・体感・直前のメッセージからの類推で時刻を書かない（値の創作にあたる）
+- 環境コンテキストの `Today's date` は**日付のみで時刻を含まない**。これを時刻の根拠にしない。会話が長引くと日付自体も古くなりうるため、日付境界が問題になる場面では `date` を実行し直す
+- 日本にサマータイムはなく JST は通年 UTC+9 固定。表示時刻がずれたときにタイムゾーン要因を疑う前に、**自分が `date` を実測したか**を確認すること
 - 日時は基本すべて JST（UTC+9）で表示すること。ソース（GitHub API / GCP ログ等）が UTC を返す場合は JST に変換し、曖昧になりうる場面では「(JST)」を併記する。ログのフィルタ条件など API に渡す値はソースのタイムゾーンのままでよい
-- Workflow など、バックグラウンドで処理を開始するときのメッセージには、そのときの日時（`YYYY-MM-DD hh:mm` 形式・JST）を記載すること
+- **UTC → JST の変換は暗算せずコマンドで行う**（macOS 実機確認済み）: `TZ=Asia/Tokyo date -j -f '%Y-%m-%dT%H:%M:%S %z' '<UTC 時刻> +0000' '+%Y-%m-%d %H:%M (JST)'`。日付をまたぐ変換（UTC 15:00 以降）を目視で処理しない
+- Workflow など、バックグラウンドで処理を開始するときのメッセージには、そのときの日時（`YYYY-MM-DD hh:mm` 形式・JST）を記載すること。**この 1 行のためだけでも `date` を実行する**。実行できない環境では時刻を書かず「(時刻未実測)」と明記する
+- サブエージェント・Workflow スクリプトは自前で時刻を取得できないことがある（Workflow スクリプトは `Date.now()` / `new Date()` が禁止）。その場合は各エージェントに `TZ=Asia/Tokyo date '+%H:%M'` を実行させ、返り値（`nowJst` 等）を使って表示する
 
 ## Clarification
 - 不明点がある場合は AskUserQuestion ツールを使って確認すること
@@ -135,6 +140,20 @@ LLM コーディングの典型的ミスを減らす行動原則。慎重さ優�
 
 ## Shell
 - この環境の `ls` は `-F` 相当のエイリアス（ディレクトリ名に末尾 `/` 付与）。`ls` 出力を完全一致でパース・フィルタする場合は `| sed 's:/*$::'` で正規化する
+
+## Claude Code CLI × 企業プロキシ (Netskope) の TLS/SSL エラー
+
+- **症状**: Claude Code CLI (native binary) v2.1.181 以降で `API Error: Unable to connect to API: SSL certificate verification failed. Check your proxy or corporate SSL certificates` が出て API に接続できない（v2.1.179 は正常）。背景は v2.1.181 の bundled Bun ランタイム更新で `NODE_OPTIONS=--use-system-ca` が無視されるようになった回帰（GitHub anthropics/claude-code #72066）。社内プロキシが全 HTTPS を組織固有の中間 CA（発行元ルートは `certadmin`）で MITM するため、システム CA を信頼できず TLS 検証が落ちる。実際の CA ホスト名は `security find-certificate -a -p /Library/Keychains/System.keychain | openssl x509 -noout -subject` 等で確認する（公開リポジトリへ同期される可能性があるため、このファイルに実ホスト名を書かない）
+- **効かない/不十分な対処**: `NODE_OPTIONS=--use-system-ca`（Bun バイナリが無視する）／ 中間 CA 証明書 1 枚だけを `NODE_EXTRA_CA_CERTS` に渡す（発行元ルート `certadmin` が欠けてチェーンが繋がらず失敗する）
+- **解決策（恒久・本セッションで v2.1.214 動作確認済み）**: キーチェーン全体＋macOS 標準ルートを 1 つの PEM に連結し `NODE_EXTRA_CA_CERTS` で渡す。`--use-system-ca` と違いチャット API 経路にもインストーラ経路にも効く:
+  ```bash
+  security find-certificate -a -p /Library/Keychains/System.keychain > ~/.local/share/certs/system-ca.pem
+  security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> ~/.local/share/certs/system-ca.pem
+  echo 'export NODE_EXTRA_CA_CERTS="$HOME/.local/share/certs/system-ca.pem"' >> ~/.zshrc && source ~/.zshrc
+  ```
+- **再発時（証明書ローテーション）**: Netskope の CA 更新でバンドルが陳腐化すると再び同じ SSL エラーになる。上の `security find-certificate` 2 本を再実行してバンドルを作り直せば復旧する
+- **切り分け（再発時の診断）**: 起動時に `warn: ignoring extra certs from <path>, load failed: ...`（または `No such file or directory`）が出るなら **PEM のパスが不在/誤り**。この警告が出ないのに API が SSL エラーなら **バンドルは読めているがルート（`certadmin`）が欠けチェーン不成立** → 完全バンドルを作り直す（単一証明書だけを渡した状態がこれ）
+- **補足**: Claude Code はネイティブインストーラ管理（`~/.local/bin/claude` → `~/.local/share/claude/versions/<ver>`、brew ではない）。特定版へ戻すなら `claude install <version>`（例: `claude install 2.1.179`）だが、完全バンドルで最新版が動くならダウングレード不要。mise/pnpm など通常の Node は `--use-system-ca`（`.mise.toml`）が今も有効で変更不要（回帰は Claude Code の Bun バイナリ固有）
 
 ## AI Agent Role Assignment
 

--- a/dotfiles/claude/settings.json
+++ b/dotfiles/claude/settings.json
@@ -132,26 +132,7 @@
     "superpowers@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "atlassian@zozo-claude-plugins": true,
-    "chrome-devtools@zozo-claude-plugins": true,
-    "context7@zozo-claude-plugins": true,
-    "datadog@zozo-claude-plugins": true,
-    "drawio@zozo-claude-plugins": true,
-    "figma@zozo-claude-plugins": true,
-    "github@zozo-claude-plugins": true,
-    "guideline-review@zozo-claude-plugins": true,
-    "sentry@zozo-claude-plugins": true,
-    "serena@zozo-claude-plugins": true,
-    "slack@zozo-claude-plugins": true,
-    "awslabs-aws-knowledge@zozo-claude-plugins": true,
-    "awslabs-aws-dataprocessing@zozo-claude-plugins": true,
-    "awslabs-aws-api@zozo-claude-plugins": true,
-    "awslabs-cloudwatch@zozo-claude-plugins": true,
-    "playwright@zozo-claude-plugins": true,
-    "near-fashion-business-ideation@new-product-marketplace": true,
-    "near-fashion-business-ops@new-product-marketplace": true,
-    "andrej-karpathy-skills@karpathy-skills": true,
-    "coding@new-product-marketplace": true
+    "andrej-karpathy-skills@karpathy-skills": true
   },
   "extraKnownMarketplaces": {
     "anthropic-agent-skills": {
@@ -181,18 +162,6 @@
       },
       "autoUpdate": true
     },
-    "zozo-claude-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "st-tech/zozo-claude-code-plugins"
-      }
-    },
-    "new-product-marketplace": {
-      "source": {
-        "source": "github",
-        "repo": "st-tech/new-product-claude-cookbook"
-      }
-    },
     "karpathy-skills": {
       "source": {
         "source": "github",
@@ -200,11 +169,10 @@
       }
     }
   },
-  "effortLevel": "max",
+  "effortLevel": "xhigh",
   "showThinkingSummaries": true,
   "skipWorkflowUsageWarning": true,
   "autoUpdates": false,
   "tui": "fullscreen",
-  "switchModelsOnFlag": true,
-  "model": "claude-fable-5[1m]"
+  "switchModelsOnFlag": true
 }

--- a/internal/global-config-pull/SKILL.md
+++ b/internal/global-config-pull/SKILL.md
@@ -25,9 +25,11 @@ metadata:
 
 **除外（同期しない）:**
 
-- 秘密情報: `.credentials.json`・`remote-settings.json`（認証情報・リモート管理設定。リポジトリに置かない）
+- 秘密情報: `.credentials.json`・`remote-settings.json`（認証情報・リモート管理設定。リポジトリに置かない）・`.config-sync-exclude`（サニタイズ対象の marketplace 名を書くローカル限定ファイル。手順 3 参照）
 - 配布物: `skills/`（npx skills / plugin marketplace の install 先。手書き設定ではなく各配布元リポジトリが正本）
-- 状態・キャッシュ: `projects/`・`plugins/`・`backups/`・`cache/`・`debug/`・`downloads/`・`file-history/`・`ide/`・`paste-cache/`・`session-env/`・`sessions/`・`shell-snapshots/`・`tasks/`・`telemetry/`・`auto-resume/`・`security/`・`.cc-writes/`・`history.jsonl`・`stats-cache.json`・`security_warnings_state_*.json`・`mcp-needs-auth-cache.json`・`.last-*`・`*.bak.*`・`.DS_Store`
+- 状態・キャッシュ: `projects/`・`plugins/`・`backups/`・`cache/`・`chrome/`（Claude in Chrome の native host wrapper。CLI が自動生成しマシン固有の絶対パスとバージョンを埋め込む）・`debug/`・`downloads/`・`file-history/`・`ide/`・`paste-cache/`・`session-env/`・`sessions/`・`shell-snapshots/`・`tasks/`・`telemetry/`・`auto-resume/`・`security/`・`.cc-writes/`・`history.jsonl`・`stats-cache.json`・`security_warnings_state_*.json`・`mcp-needs-auth-cache.json`・`.last-*`・`*.bak.*`・`.DS_Store`
+
+**このリポジトリは public** のため、ミラーに社内・非公開の情報を出さない（手順 2 のパス正規化・手順 3 のサニタイズ・手順 4 の秘密情報チェックがその防波堤）。
 
 ## 手順
 
@@ -50,28 +52,42 @@ metadata:
    ```
    grep がヒットした場合は該当箇所を確認し、`~` 表記へ手動で直してから進める。
 
-3. **秘密情報チェック（Security ルール準拠）:** ミラーに実トークン・API キー等の値が混入していないか確認する:
+3. **サニタイズ（非公開 marketplace の除去）:** `settings.json` には社内・非公開の plugin marketplace 名やそのリポジトリパス（`extraKnownMarketplaces.<名前>.source.repo`）が入りうる。public リポジトリのミラーへ出さないため、除外対象を**ローカル限定ファイル** `~/.claude/.config-sync-exclude`（1 行 1 marketplace 名。`#` 始まりと空行は無視。marketplace 名自体を公開リポジトリに書かないためのローカル管理）に列挙し、ミラー側から取り除く。`jq` が必要:
+   ```bash
+   EXCLUDE=~/.claude/.config-sync-exclude
+   if [ -f "$EXCLUDE" ]; then
+     MPS=$(grep -vE '^[[:space:]]*(#|$)' "$EXCLUDE" | jq -R . | jq -s .)
+     jq --argjson mps "$MPS" '
+       (if has("enabledPlugins") then .enabledPlugins |= with_entries((.key | split("@") | last) as $m | select(($mps | index($m)) == null)) else . end)
+       | (if has("extraKnownMarketplaces") then .extraKnownMarketplaces |= with_entries(.key as $k | select(($mps | index($k)) == null)) else . end)
+     ' dotfiles/claude/settings.json > "${TMPDIR:-/tmp}/settings-sanitized.json" \
+       && mv "${TMPDIR:-/tmp}/settings-sanitized.json" dotfiles/claude/settings.json
+   fi
+   ```
+   除去されるのは `enabledPlugins` の `"<plugin>@<marketplace>"` エントリと `extraKnownMarketplaces` の同名キー。**live 側（`~/.claude/settings.json`）は変更しない**ため手元の動作に影響はなく、`global-config-push` は反映時に live の該当エントリを保持する（両スキルで対の実装。片方だけ変えない）。除外ファイルが無い環境ではサニタイズをスキップする（従来動作）。
+
+4. **秘密情報チェック（Security ルール準拠）:** ミラーに実トークン・API キー等の値が混入していないか確認する:
    ```bash
    grep -rniE '(api[_-]?key|token|secret|password|credential)' dotfiles/claude/ || echo "OK: 秘密情報らしき語なし"
    ```
    ヒット行は必ず目視で判断する（キー名の参照・許可ルール・ドキュメント記述は問題ない。実際の値が入っていたら該当ファイルをミラーから外し、除外リストへの追加を検討する）。
 
-4. **新しい同期候補の探索:** `~/.claude/` 直下に、同期対象にも既知の除外にも該当しない項目が増えていないか確認する（`sed` は `ls` が `-F` エイリアスの環境でも完全一致が効くよう末尾スラッシュを除去する）:
+5. **新しい同期候補の探索:** `~/.claude/` 直下に、同期対象にも既知の除外にも該当しない項目が増えていないか確認する（`sed` は `ls` が `-F` エイリアスの環境でも完全一致が効くよう末尾スラッシュを除去する）:
    ```bash
    ls -A ~/.claude | sed 's:/*$::' \
      | grep -vE '^(CLAUDE\.md|settings\.json|statusline-command\.sh|keybindings\.json|\.mcp\.json|rules|hooks|agents|commands)$' \
-     | grep -vE '^(skills|projects|plugins|backups|cache|debug|downloads|file-history|ide|paste-cache|session-env|sessions|shell-snapshots|tasks|telemetry|auto-resume|security|\.cc-writes|\.credentials\.json|remote-settings\.json|history\.jsonl|stats-cache\.json|mcp-needs-auth-cache\.json|\.DS_Store)$' \
+     | grep -vE '^(skills|projects|plugins|backups|cache|chrome|debug|downloads|file-history|ide|paste-cache|session-env|sessions|shell-snapshots|tasks|telemetry|auto-resume|security|\.cc-writes|\.credentials\.json|remote-settings\.json|\.config-sync-exclude|history\.jsonl|stats-cache\.json|mcp-needs-auth-cache\.json|\.DS_Store)$' \
      | grep -vE '^(security_warnings_state_.*|\.last-.*|.*\.bak\..*)$' \
      || echo "新しい同期候補なし"
    ```
    ヒットした項目は「手書きのグローバル設定か / 状態・キャッシュか」を判断し、設定なら本 SKILL.md と global-config-push の対象リストに追加してから再実行、状態・キャッシュなら両スキルの除外リストと本コマンドの除外パターンに追記する。
 
-5. **差分確認:**
+6. **差分確認:**
    ```bash
    git status --short dotfiles/claude/
    git diff dotfiles/claude/
    ```
 
-6. 差分サマリをユーザーに日本語で報告する（変更なし／変更ありの場合は変更ファイル名と概要を示す）。
+7. 差分サマリをユーザーに日本語で報告する（変更なし／変更ありの場合は変更ファイル名と概要を示す）。
 
-7. コミットはユーザーが明示的に依頼した場合のみ行う（`/smart-commit` を使う）。
+8. コミットはユーザーが明示的に依頼した場合のみ行う（`/smart-commit` を使う）。

--- a/internal/global-config-push/SKILL.md
+++ b/internal/global-config-push/SKILL.md
@@ -19,6 +19,8 @@ pull（global-config-pull）と同一。ミラー側に存在するものだけ�
 
 push は追加・上書きのみ行い、`~/.claude/` 側にしかないファイルは削除しない（ローカル限定ファイルの保護。削除の反映＝ミラー同期は pull 側のみ）。
 
+`settings.json` だけは単純コピーではなく**マージ**で反映する（手順 3）。pull 側がミラー作成時に (a) `$HOME` を `~` へ正規化し、(b) `~/.claude/.config-sync-exclude` に列挙した非公開 marketplace のエントリを除去しているため、そのまま上書きすると live の絶対パスが `~` リテラルに化け、社内 marketplace の設定が消えるため。
+
 ## 手順
 
 リポジトリルートで実行する。
@@ -47,7 +49,7 @@ push は追加・上書きのみ行い、`~/.claude/` 側にしかないファ�
 
 3. **コピー実行（追加・上書きのみ。削除はしない）:**
    ```bash
-   for f in CLAUDE.md settings.json statusline-command.sh keybindings.json .mcp.json; do
+   for f in CLAUDE.md statusline-command.sh keybindings.json .mcp.json; do
      [ -f dotfiles/claude/"$f" ] && cp dotfiles/claude/"$f" ~/.claude/"$f"
    done
    for d in rules hooks agents commands; do
@@ -56,13 +58,38 @@ push は追加・上書きのみ行い、`~/.claude/` 側にしかないファ�
    chmod +x ~/.claude/hooks/*.sh ~/.claude/statusline-command.sh 2>/dev/null || true
    ```
 
+   `settings.json` は **`~` の展開 + 非公開 marketplace の保持**を行ってから反映する（`jq` が必要。live 側が無い初回はミラーをそのまま置く）:
+   ```bash
+   MIRROR=dotfiles/claude/settings.json
+   if [ -f "$MIRROR" ]; then
+     TMP="${TMPDIR:-/tmp}/settings-push.json"
+     sed "s|\"~/|\"${HOME}/|g" "$MIRROR" > "$TMP"
+     if [ -f ~/.claude/settings.json ]; then
+       EXCLUDE=~/.claude/.config-sync-exclude
+       MPS=$([ -f "$EXCLUDE" ] && grep -vE '^[[:space:]]*(#|$)' "$EXCLUDE" | jq -R . | jq -s . || echo '[]')
+       jq -s --argjson mps "$MPS" '
+         .[0] as $mirror | .[1] as $live
+         | $mirror
+         | .enabledPlugins = (($mirror.enabledPlugins // {}) + (($live.enabledPlugins // {}) | with_entries((.key | split("@") | last) as $m | select(($mps | index($m)) != null))))
+         | .extraKnownMarketplaces = (($mirror.extraKnownMarketplaces // {}) + (($live.extraKnownMarketplaces // {}) | with_entries(.key as $k | select(($mps | index($k)) != null))))
+       ' "$TMP" ~/.claude/settings.json > "${TMP}.merged" && mv "${TMP}.merged" "$TMP"
+     fi
+     jq -e . "$TMP" >/dev/null && cp "$TMP" ~/.claude/settings.json
+   fi
+   ```
+   `jq -e .` の妥当性チェックを通ったものだけ反映する（壊れた JSON で live 設定を潰さない）。`jq` が無い環境では**このステップを飛ばし**、settings.json は反映せずその旨を報告する（単純コピーで代替しない）。
+
 4. **確認:**
    ```bash
-   for f in CLAUDE.md settings.json statusline-command.sh keybindings.json .mcp.json; do
+   for f in CLAUDE.md statusline-command.sh keybindings.json .mcp.json; do
      [ -f dotfiles/claude/"$f" ] && { diff dotfiles/claude/"$f" ~/.claude/"$f" >/dev/null && echo "$f: OK" || echo "$f: 差分あり（要確認）"; }
    done
    for d in rules hooks agents commands; do
      [ -d dotfiles/claude/"$d" ] && { echo "--- $d/"; diff -r dotfiles/claude/"$d" ~/.claude/"$d"; }
    done
+   # settings.json はマージ反映のため一致しないのが正常。ミラー側の内容が live に入ったかを確認する
+   jq -e . ~/.claude/settings.json >/dev/null && echo "settings.json: 妥当な JSON"
+   echo "live のみに残る非公開 marketplace: $(jq -r '.extraKnownMarketplaces | keys | join(",")' ~/.claude/settings.json)"
+   grep -c '"~/' ~/.claude/settings.json | sed 's/^/live に残る ~ リテラル: /'
    ```
-   結果を日本語で報告する。バックアップパスも提示すること。ディレクトリの diff で `Only in ~/.claude/...` が出た場合は、ミラー対象外（ローカル限定）のファイルを示すだけなので、ミラー側ファイルが一致していれば反映は成功と判断してよい。
+   結果を日本語で報告する。バックアップパスも提示すること。ディレクトリの diff で `Only in ~/.claude/...` が出た場合は、ミラー対象外（ローカル限定）のファイルを示すだけなので、ミラー側ファイルが一致していれば反映は成功と判断してよい。`settings.json` は**マージ反映のためミラーと一致しないのが正常**で、確認すべきは「妥当な JSON であること」「非公開 marketplace が live に残っていること」「`~` リテラルが 0 件であること」の 3 点。


### PR DESCRIPTION
## 概要
public リポジトリのミラー `dotfiles/claude/` に社内・非公開の情報が入らないよう、`global-config-pull` / `global-config-push` に対のサニタイズ機構を追加し、あわせて現在のグローバル設定を取り込む。

## 変更内容
- **pull**: `settings.json` から非公開 marketplace のエントリを除去する手順を新設（`enabledPlugins` の `"<plugin>@<marketplace>"` と `extraKnownMarketplaces` の同名キー）。除外対象の marketplace 名自体も社内情報のため、ローカル限定の `~/.claude/.config-sync-exclude` に置き両スキルが読む（不在時はスキップ＝従来動作）
- **push**: `settings.json` を単純コピーからマージへ変更し、live 側の非公開 marketplace を保持。あわせて `~` → `$HOME` の逆正規化を追加
- 除外リストに `chrome/`（Claude in Chrome の自動生成 wrapper）と `.config-sync-exclude` を追加
- `CLAUDE.md` 記述ルールに「public なのでミラーに社内情報を入れない」を明記
- 取り込んだグローバル設定の変更: Time Display の厳密化 / 企業プロキシ TLS の節から社内 CA ホスト名を除去 / `effortLevel` の記述から実値を削除（陳腐化防止）

## レビュアー向け補足
**なぜマージ方式にしたか**: ミラーを書き換えるだけだと、push が平文コピーのため偽の値が実設定へ書き戻り、プラグイン設定が壊れる。pull でサニタイズ・push で復元のペアにすることで、公開側から社内情報を消しつつ手元の設定を保つ。

**`~` の逆正規化は既存欠陥の修正**: pull が `$HOME` → `~` に正規化する一方 push は平文コピーだったため、push すると `permissions.additionalDirectories` に `~/...` リテラルが書き戻る状態だった（live は現在すべて絶対パス）。settings.json の反映経路を書き換えるついでに解消した。

**`jq` 依存**: サニタイズ・マージとも `jq` を使う。push は `jq` 不在時に settings.json を反映せず報告する（単純コピーで代替すると、サニタイズ済みミラーが live を潰すため）。

**検証**: 両 SKILL.md の bash ブロックを抽出して `bash -n`（pull 6 / push 5）PASS。サニタイズ後のミラーに社内識別子の grep 0 件・`jq -e .` PASS。push のマージを live へ書かず一時ファイルで実行し、`jq -S` 正規化して live と `diff` が完全一致することを確認（プラグイン 33 件・marketplace 7 件が復元、`~` リテラル 0 件）。

**既知の制約**: 既存コミットの履歴には社内 org・非公開リポジトリのパスが残る。除去には履歴書き換えが必要だが、本リポジトリは git tree-SHA ベース配布（`#v<X.Y.Z>` pin）のため配布済み pin が壊れ、force push も規約で禁止のため実施していない（ユーザー判断で許容済み）。
