### PR TITLE
feat(smart-issue): codex レビューを Codex CLI ホストでも独立実行できるようにする

### DIFF
--- a/skills/smart-issue-plan/README.md
+++ b/skills/smart-issue-plan/README.md
@@ -20,7 +20,7 @@ GitHub Issue の実装計画を作成・更新するスキル。
 | オプション        | 説明                                       |
 | ----------------- | ------------------------------------------ |
 | `-p <プロンプト>` | 計画の観点・制約に関する追加指示を渡す     |
-| `--codex-review-loop`（`-cdxrl`） | 投稿前に Codex 標準レビューループを実施し、収束後は承認ゲートなしで自動投稿する（Claude Code + Codex プラグイン環境前提） |
+| `--codex-review-loop`（`-cdxrl`） | 投稿前に Codex 標準レビューループを実施し、収束後は承認ゲートなしで自動投稿する（Claude Code + Codex プラグイン環境、または Codex CLI ホスト〔本 skill 自体を Codex CLI が実行している場合〕で `codex exec` が使える環境が前提） |
 | `--codex-advs-review-loop`（`-cdxarl`） | 投稿前に Claude=Breaker × Codex=Judge の敵対的レビューループを実施する。収束後の自動投稿は標準と同じ |
 | `--claude-review-loop`（`-cldrl`） | 投稿前に Opus レビュワーエージェント（包括ラウンドのみ観点を G1/G2/G3 の 3 グループに分割し並列起動）による標準計画レビューループを実施する（Codex 不要・Claude Code の Workflow ツール前提）。収束後の自動投稿は codex 系と同じ |
 | `--claude-adv-review-loop`（`-cldarl`） | 投稿前に独立 Opus の Breaker × Judge による敵対的計画レビューループを実施する（Codex 不要・Workflow ツール前提） |
@@ -33,7 +33,7 @@ GitHub Issue の実装計画を作成・更新するスキル。
 
 **codex 系**（別系統モデル Codex による独立レビュー）:
 
-- **標準（`--codex-review-loop` / `-cdxrl`）**: Codex（`codex:rescue` 経由）が単独で計画とコードを照合してレビューする
+- **標準（`--codex-review-loop` / `-cdxrl`）**: Codex（Claude Code ホストは `codex:rescue` 経由、Codex CLI ホスト＝本 skill 自体を Codex CLI が実行している場合は `codex exec` の独立セッション）が単独で計画とコードを照合してレビューする
 - **敵対的（`--codex-advs-review-loop` / `-cdxarl`）**: Claude=Breaker（設計への攻撃シナリオ・脅威・欠落コントロールの列挙）× Codex=Judge（真の欠陥かノイズかを裁定）の二者構造。計画にはテスト対象のコードがないため、反例テストの代わりに攻撃シナリオを用いる。`code-reviewer-adversarial` スキルは `disable-model-invocation` のため直接委譲できないので、その二者構造をループ内にインライン再現している
 
 **claude 系**（Codex 不要・Claude Code の Workflow ツールで起動する独立 Opus エージェント。コンテキスト隔離 + 役割分離で独立性を担保）:
@@ -44,10 +44,10 @@ GitHub Issue の実装計画を作成・更新するスキル。
 
 共通:
 
-- **セキュリティ自動発動**: 認証・個人情報・決済などセキュリティ影響を Issue や計画から検出したら、フラグ未指定でも敵対的レビューを自動で有効化する（発動理由を明示）。系統はフラグ明示ならその系統、未指定なら `codex:rescue` 利用可能時は codex・不能時は claude にフォールバックする。ただしこの自動発動のみのケースでは**投稿前の承認ゲートを維持する**（外部投稿の自動化は明示オプトイン時のみ）
+- **セキュリティ自動発動**: 認証・個人情報・決済などセキュリティ影響を Issue や計画から検出したら、フラグ未指定でも敵対的レビューを自動で有効化する（発動理由を明示）。系統はフラグ明示ならその系統、未指定なら codex 系のレビュー取得経路（`codex:rescue` / `codex exec`）が利用可能時は codex・不能時は claude にフォールバックする。ただしこの自動発動のみのケースでは**投稿前の承認ゲートを維持する**（外部投稿の自動化は明示オプトイン時のみ）
 - 収束後の自動投稿（フラグ明示時のみ）はプレビュー承認をスキップする
 - 投稿本文の末尾に `🤖 Codex レビュー済み（標準…）` / `🤖 Codex 敵対的レビュー済み（Breaker×Judge…）` / `🤖 Claude レビュー済み（標準…）` / `🤖 Claude 敵対的レビュー済み（Breaker×Judge=独立 Opus…）` を記載する
-- レビューが使えない環境（codex 系は `codex:rescue` 不能、claude 系は Workflow ツール不能）では Claude がレビュー・裁定を代行せず、通常フロー（承認ゲートあり）にフォールバックする（レビュー済み表記なし）
+- レビューが使えない環境（codex 系は `codex:rescue` / `codex exec` いずれも不能、claude 系は Workflow ツール不能）では Claude がレビュー・裁定を代行せず、通常フロー（承認ゲートあり）にフォールバックする（レビュー済み表記なし）
 
 ## 動作モード
 
@@ -70,6 +70,6 @@ GitHub Issue の実装計画を作成・更新するスキル。
 
 - **git** — 分析時点 SHA の記録（`git rev-parse`）と更新モードでの変更点特定（`git log`）に使用（git が使えない環境では SHA は「未記録」となり、更新モードの差分検出が制限される）
 - **GitHub MCP サーバー** — Issue の読み取り・計画コメント投稿に必須（[GitHub MCP plugin](https://github.com/anthropics/claude-code-plugins/tree/main/github)）
-- **Codex プラグイン（`codex:rescue` スキル）** — `--codex-review-loop` / `--codex-advs-review-loop` 使用時のみ必須。セキュリティ自動発動時は codex 系優先だが、不在なら claude 系（Workflow）へフォールバックする
+- **Codex プラグイン（`codex:rescue` スキル）または Codex CLI（`codex exec`）** — `--codex-review-loop` / `--codex-advs-review-loop` 使用時のみ必須（Claude Code ホストは `codex:rescue` スキル、本 skill 自体を Codex CLI が実行している場合は `codex exec` が使えること）。セキュリティ自動発動時は codex 系優先だが、不在なら claude 系（Workflow）へフォールバックする
 - **Workflow ツール** — `--claude-review-loop` / `--claude-adv-review-loop` 使用時、および Codex 不在でのセキュリティ自動発動時に必須（Claude Code 固有。利用できない環境では claude 系レビューは実施されず通常フローへ degrade する）
 - **AskUserQuestion** — Issue 番号・要件の確認と、レビューループ 3 ラウンドごとの続行確認・仕様未定の確認に使用（Claude Code 拡張。他エージェントではテキスト確認にフォールバック）

--- a/skills/smart-issue-plan/SKILL.md
+++ b/skills/smart-issue-plan/SKILL.md
@@ -143,7 +143,7 @@ Issue の内容から関連するキーワード・ファイルパス・機能�
 
 ### 6. プレビューと承認
 
-> レビューループを実施し、かつ `{ループ明示}` = true の場合はこの手順をスキップする（オプション指定が投稿のオプトイン）。セキュリティ自動発動のみ（`{ループ明示}` = false）の場合、およびループのフォールバック（codex:rescue 利用不能 / Workflow 利用不能）時は通常どおり実施する。
+> レビューループを実施し、かつ `{ループ明示}` = true の場合はこの手順をスキップする（オプション指定が投稿のオプトイン）。セキュリティ自動発動のみ（`{ループ明示}` = false）の場合、およびループのフォールバック（codex:rescue / codex exec 利用不能 / Workflow 利用不能）時は通常どおり実施する。
 
 作成した計画の全文をユーザーに提示し、投稿前に承認を得る。
 
@@ -203,7 +203,7 @@ Issue の内容から関連するキーワード・ファイルパス・機能�
 セキュリティ影響ありと判定し、かつ `{レビューモード}` が `off` または `standard` の場合、`{レビューモード}` を `adversarial` に昇格させ、発動理由（検出したシグナル）をユーザーに 1 行で明示する。`{レビュー系統}` は次のとおり決める:
 
 - 系統フラグが明示されている → その系統のまま adversarial へ昇格
-- フラグ未指定（`off` からの自動発動） → `codex:rescue` が利用可能なら `codex`、利用不能なら `claude`（Workflow 必須）。両方利用不能ならフォールバック（後述）に従う
+- フラグ未指定（`off` からの自動発動） → codex 系のレビュー取得経路（Claude Code ホストの `codex:rescue` / Codex CLI ホストの `codex exec`）のいずれかが利用可能なら `codex`、いずれも利用不能なら `claude`（Workflow 必須）。両方利用不能ならフォールバック（後述）に従う
 
 > `{ループ明示}` = false（フラグ未指定でセキュリティ検出により発動）の場合、レビューは実施するが **手順 6 / 8c の承認ゲートは維持する**（外部への投稿を伴う自動化は明示オプトイン時のみ）。
 
@@ -240,19 +240,24 @@ Issue の内容から関連するキーワード・ファイルパス・機能�
 
 **実行形態**:
 
-- **codex 系** — オーケストレーターがラウンド単位で回す。レビュー・裁定は Skill ツールで `codex:rescue` を呼ぶ（下記「標準モード」「敵対的モード」）。妥当性判定・計画修正はオーケストレーターが行う。敵対の裁定に「仕様未定」が含まれる場合は、修正前にオーケストレーターが AskUserQuestion でユーザーに仕様を確認し、確定内容を計画に反映する
+- **codex 系** — オーケストレーターがラウンド単位で回す。レビュー・裁定の取得はホストで分岐する（**Claude Code ホスト**は Skill ツールで `codex:rescue` を呼ぶ、**Codex CLI ホスト**＝本 skill 自体を Codex CLI が実行している場合は `codex exec` で独立した新規セッションを起動する。詳細は下記「標準モード」「敵対的モード」）。妥当性判定・計画修正はオーケストレーターが行う。敵対の裁定に「仕様未定」が含まれる場合は、修正前にオーケストレーターが AskUserQuestion でユーザーに仕様を確認し、確定内容を計画に反映する
 - **claude 系** — 骨格 1〜4 の 1 セット（最大 3 ラウンド）を雛形 `sip-plan-review-set` の Workflow 1 回で実行する。オーケストレーターは返却（`converged` / `records` / `specQuestions`）を受けて、上限チェック（AskUserQuestion）と裁定「仕様未定」のユーザー確認を行う（下記「claude 系」）
 
 #### 標準モード（codex 系: --codex-review-loop）
 
-[assets/codex-review-prompt.md](assets/codex-review-prompt.md) のテンプレートを埋め、Skill ツールで `codex:rescue` を呼び出す。Codex が単独で計画とコードを照合してレビューする。
+[assets/codex-review-prompt.md](assets/codex-review-prompt.md) のテンプレートを埋め、レビューを取得する:
+
+- **Claude Code ホスト**（Skill ツールが使える）: Skill ツールで `codex:rescue` を呼び出す
+- **Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している。`codex:rescue` は Claude Code 専用のため存在しない）: `codex exec`（非対話・毎回新規セッション）を Bash から起動しテンプレートを渡す。計画を作成している現在のセッションとは独立した新規セッションでレビューを取得し、同一セッション内で自己レビューを完結させない（独立性が失われるため）
+
+Codex が単独で計画とコードを照合してレビューする。
 
 #### 敵対的モード（codex 系: --codex-advs-review-loop / セキュリティ自動発動）
 
 Claude=Breaker × Codex=Judge の二者構造でレビューする。計画にはテスト対象のコードがないため、反例テストの代わりに **設計への攻撃シナリオ** を用いる。`code-reviewer-adversarial` スキルは `disable-model-invocation` のため Skill ツールから呼べない。その二者構造を本ループ内にインラインで再現する:
 
 1. **Breaker（Claude）** — 計画を「破る」観点で、設計が耐えるべき具体的な攻撃シナリオ・脅威・欠落コントロールを列挙する。デフォルトは懐疑: 正常系（happy path）しか想定していない手順は実在の弱点として扱い、「後で対応する」前提や部分的な対処に信用を与えない。セキュリティ観点では STRIDE（なりすまし・改ざん・否認・情報漏洩・DoS・権限昇格）・信頼境界・認可漏れ・PII/秘密情報の露出・注入面を、一般観点では移行失敗・後方互換性破壊・version skew／スキーマドリフト・品質ゲートの抜け・運用/保守/可用性の設計欠落（可観測性・デプロイ/ロールバック・障害時や依存劣化時の挙動・単一障害点・過度な結合）・データ整合性/性能の設計欠落（トランザクション境界・冪等性・並行更新・部分失敗・不可逆な状態変更・N+1 や過剰 I/O）・テストカバレッジ計画の不足・アーキテクチャ層責務の逸脱を洗い出す。「レビュー基準の収集」で得たプロジェクト固有ルールがあれば、その観点も攻撃シナリオに含める。各シナリオに、計画のどの手順・前提が対処できていないかを付す
-2. **Judge（Codex）** — [assets/codex-judge-prompt.md](assets/codex-judge-prompt.md) のテンプレートに計画全文と Breaker の攻撃シナリオを埋め、Skill ツールで `codex:rescue` を呼び出す。Codex はリポジトリの実コードと照合し、各シナリオを「真の欠陥 / 仕様未定 / 低優先度 / ノイズ」に裁定し、独立にも計画の欠陥を挙げる
+2. **Judge（Codex）** — [assets/codex-judge-prompt.md](assets/codex-judge-prompt.md) のテンプレートに計画全文と Breaker の攻撃シナリオを埋め、レビューを取得する。**Claude Code ホスト**では Skill ツールで `codex:rescue` を呼び出す。**Codex CLI ホスト**（`codex:rescue` が存在しない）では `codex exec` を Bash から起動し、Breaker（現在のセッション）とは独立した新規セッションで裁定させる。Codex はリポジトリの実コードと照合し、各シナリオを「真の欠陥 / 仕様未定 / 低優先度 / ノイズ」に裁定し、独立にも計画の欠陥を挙げる
 3. Judge が「真の欠陥」「仕様未定」に分類した指摘を、共通骨格の手順 2（妥当性判定）に渡す
 
 > **共犯化の回避**: Judge（Codex）の裁定を Claude が模擬・代行しない。Breaker（Claude）と Judge（Codex）が別系統モデルであることが敵対的レビューの核。
@@ -299,10 +304,10 @@ Workflow 返却の扱い（詳細は [references/agent-orchestration.md](referen
 
 ### フォールバック
 
-**codex 系（codex:rescue 利用不能時）** — 以下のいずれかに該当する場合:
+**codex 系（codex:rescue / codex exec が利用不能時）** — 以下のいずれかに該当する場合:
 
-- **呼び出し不能** — Codex プラグイン未導入・Codex CLI 未設定・他エージェント環境などで `codex:rescue` が呼び出せない
-- **復旧不能なハング** — 呼び出し済みのレビュー/裁定が返らず（silent death）、[assets/codex-review-prompt.md](assets/codex-review-prompt.md) の「運用ノート」に従った復旧（cancel → `--resume` 再投入）を 2 回試みても完了しない（ハング時は即フォールバックせず、必ず先に復旧を試みる）
+- **呼び出し不能** — レビュー取得の経路（Claude Code ホストの `codex:rescue` / Codex CLI ホストの `codex exec`）が使えない。具体的には: Claude Code ホストで Codex プラグイン未導入・Codex CLI 未設定により `codex:rescue` が呼び出せない、Codex CLI ホストで `codex` バイナリが未インストール・未認証などで `codex exec` の実行に失敗する、またはそれ以外のエージェント環境でいずれの経路も提供されない
+- **復旧不能なハング** — 呼び出し済みのレビュー/裁定が返らず（silent death）、[assets/codex-review-prompt.md](assets/codex-review-prompt.md) の「運用ノート」に従った復旧（cancel → `--resume` 再投入）を 2 回試みても完了しない（ハング時は即フォールバックせず、必ず先に復旧を試みる。Codex CLI ホストの `codex exec` はジョブレジストリを持たない同期呼び出しのため、この複雑な復旧手順は対象外 — 単純にタイムアウト・失敗として「呼び出し不能」に倒す）
 
 該当した場合:
 

--- a/skills/smart-issue-plan/assets/codex-judge-prompt.md
+++ b/skills/smart-issue-plan/assets/codex-judge-prompt.md
@@ -1,10 +1,10 @@
 # Codex Judge 依頼テンプレート（敵対的モード・実装計画）
 
-敵対的モード（`--codex-advs-review-loop` / セキュリティ自動発動）のループで、Breaker（Claude）が生成した設計への攻撃シナリオを Codex（Judge）に裁定させる依頼文のテンプレート。計画にはテスト対象のコードがないため、反例テストの代わりに攻撃シナリオを用いる。`<>` を埋めて `codex:rescue` に task として渡す。標準モードのレビュー依頼は [codex-review-prompt.md](codex-review-prompt.md) を使う。
+敵対的モード（`--codex-advs-review-loop` / セキュリティ自動発動）のループで、Breaker（Claude）が生成した設計への攻撃シナリオを Codex（Judge）に裁定させる依頼文のテンプレート。計画にはテスト対象のコードがないため、反例テストの代わりに攻撃シナリオを用いる。`<>` を埋めて、**Claude Code ホスト**では `codex:rescue` へ task として渡し、**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している場合。`codex:rescue` は存在しない）では `codex exec` の入力として渡す。標準モードのレビュー依頼は [codex-review-prompt.md](codex-review-prompt.md) を使う。
 
 ---
 
-## codex:rescue への依頼文テンプレート
+## Codex への依頼文テンプレート（codex:rescue / codex exec 共通）
 
 ```
 あなたは GitHub Issue の実装計画の Judge（裁定者）として振る舞う。
@@ -71,11 +71,11 @@ Breaker に迎合せず、独立した視点で判断すること。
 
 ## 呼び出し時の注意
 
-- このテンプレート全体を埋めたうえで、Skill ツールの `codex:rescue` に task として渡す
+- このテンプレート全体を埋めたうえで渡す。**Claude Code ホスト**では Skill ツールの `codex:rescue` に task として渡す。**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している。`codex:rescue` は存在しない）では `codex exec`（例: `codex exec --sandbox read-only -C <リポジトリルート> -` で stdin からテンプレートを読ませる。裁定のみでファイル変更をさせないため `--sandbox read-only` を明示する）を Bash から起動する。いずれの経路でも、Breaker を実施したセッションとは独立した新規セッションで裁定させる
 - Codex はリポジトリにアクセスできるため、計画とコードの照合（ファイル実在確認・前提検証・シナリオの成立性）は Codex 側に行わせる
 - Codex に計画やコードの修正を行わせない（裁定のみ）。修正は Claude 側の妥当性判定（過剰対応チェック）を経てから行う
 - 返ってきた裁定の再解釈・要約による弱体化をしない（妥当性判定は採用 / 不採用の分類と理由の明記のみ）
 
 ## 運用ノート: silent death（ハング・静止死）からの復旧
 
-silent death の検知・回収・復旧（cancel → `--resume` 再投入）・予防の手順は [codex-review-prompt.md](codex-review-prompt.md) の「運用ノート」に従う。復旧を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue 利用不能時）」に切り替える。
+silent death の検知・回収・復旧（cancel → `--resume` 再投入）・予防の手順（Claude Code ホスト / codex:rescue 経由）、および Codex CLI ホストでの補足は [codex-review-prompt.md](codex-review-prompt.md) の「運用ノート」に従う。復旧を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue / codex exec が利用不能時）」に切り替える。

--- a/skills/smart-issue-plan/assets/codex-review-prompt.md
+++ b/skills/smart-issue-plan/assets/codex-review-prompt.md
@@ -1,10 +1,10 @@
 # Codex レビュー依頼テンプレート（実装計画）
 
-標準モード（`--codex-review-loop`）のループ手順 1 で `codex:rescue` に渡す依頼文のテンプレート。`<>` を埋めて task として渡す。敵対的モード（`--codex-advs-review-loop`）の Judge 依頼は [codex-judge-prompt.md](codex-judge-prompt.md) を使う。
+標準モード（`--codex-review-loop`）のループ手順 1 でレビューを取得する依頼文のテンプレート。`<>` を埋めて、**Claude Code ホスト**では `codex:rescue` へ task として渡し、**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している場合。`codex:rescue` は存在しない）では `codex exec` の入力として渡す。敵対的モード（`--codex-advs-review-loop`）の Judge 依頼は [codex-judge-prompt.md](codex-judge-prompt.md) を使う。
 
 ---
 
-## codex:rescue への依頼文テンプレート
+## Codex への依頼文テンプレート（codex:rescue / codex exec 共通）
 
 ```
 あなたは GitHub Issue の実装計画のレビュアーとして振る舞う。
@@ -59,12 +59,12 @@
 
 ## 呼び出し時の注意
 
-- このテンプレート全体を埋めたうえで、Skill ツールの `codex:rescue` に task として渡す
+- このテンプレート全体を埋めたうえで渡す。**Claude Code ホスト**では Skill ツールの `codex:rescue` に task として渡す。**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している。`codex:rescue` は存在しない）では `codex exec`（非対話・毎回新規セッション。例: `codex exec --sandbox read-only -C <リポジトリルート> -` で stdin からテンプレートを読ませる。レビューのみでファイル変更をさせないため `--sandbox read-only` を明示する）を Bash から起動する。いずれの経路でも、計画を作成している現在のセッションとは独立した新規セッションでレビューを取得し、同一セッション内で自己レビューを完結させない
 - Codex はリポジトリにアクセスできるため、計画とコードの照合（ファイル実在確認・前提検証）は Codex 側に行わせる
 - Codex に計画やコードの修正を行わせない（レビューのみ）。修正は Claude 側の妥当性判定を経てから行う
 - 返ってきた指摘の再解釈・要約による弱体化をしない（妥当性判定は採用 / 不採用の分類と理由の明記のみ）
 
-## 運用ノート: silent death（ハング・静止死）からの復旧
+## 運用ノート: silent death（ハング・静止死）からの復旧（Claude Code ホスト / codex:rescue 経由）
 
 Codex のレビュープロセスは、ジョブレジストリ上 `running` のまま静かに死ぬことがある。レビュー結果がいつまでも返らない場合は、フォールバックに切り替える前に以下の順で復旧を試みる:
 
@@ -73,4 +73,8 @@ Codex のレビュープロセスは、ジョブレジストリ上 `running` の
 3. **復旧（resume が最効率）** — companion の cancel（`/codex:cancel`）で stale ジョブを落とす → resume 候補が復活する（`task-resume-candidate` が `available: true` を返す）→ `--resume` を付けて `codex:rescue` を再投入する。調査コンテキストを引き継いで続きから実行されるため、fresh 再実行より大幅に速い
 4. **予防** — companion を Bash で直接起動する経路では timeout を 600000ms（10 分）に明示する（デフォルト 120 秒では長いレビューが親側から切られる）。長時間が見込まれるレビューは `--background` 実行でプロセスのライフサイクルを呼び出し元の Bash から切り離すことを検討する
 
-復旧（cancel → `--resume` 再投入）を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue 利用不能時）」に切り替える。
+復旧（cancel → `--resume` 再投入）を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue / codex exec が利用不能時）」に切り替える。
+
+## Codex CLI ホストでの補足
+
+`codex exec` は呼び出し元の Bash（Codex CLI 自身が実行する shell）内で同期的に完了を待つ同期呼び出しで、上記の companion 側ジョブレジストリによる stall 検知・復旧手順の対象外である（`codex exec` 自体のセッション記録の有無は関知しない。復旧手段として使えるのは `codex exec resume` 程度）。長いレビューでタイムアウトしないよう呼び出し側の Bash の timeout を十分に長く取り、それでも応答がなく完了しない場合は複雑な復旧手順を適用せず、そのまま「フォールバック（codex:rescue / codex exec が利用不能時）」に切り替える。

--- a/skills/smart-issue-resolve/README.md
+++ b/skills/smart-issue-resolve/README.md
@@ -20,7 +20,7 @@ GitHub Issue ID を受け取り、Issue を読み込んでブランチを作成�
 | オプション        | 説明                                     |
 | ----------------- | ---------------------------------------- |
 | `-p <プロンプト>` | 作業に関する追加指示（実装方針・制約等） |
-| `--codex-review-loop`（`-cdxrl`） | 実装後に Codex 標準レビューループを実施し、収束後にコミット・PR 作成まで自動で行う（Codex プラグイン前提） |
+| `--codex-review-loop`（`-cdxrl`） | 実装後に Codex 標準レビューループを実施し、収束後にコミット・PR 作成まで自動で行う（Claude Code + Codex プラグイン環境、または Codex CLI ホスト〔本 skill 自体を Codex CLI が実行している場合〕で `codex exec` が使える環境が前提） |
 | `--codex-advs-review-loop`（`-cdxarl`） | Breaker（独立 Sonnet）× Codex=Judge の敵対的レビューループ。収束後の自動コミット・PR は標準と同じ |
 | `--claude-review-loop`（`-cldrl`） | Opus レビュワーエージェント（包括ラウンドのみ観点を G1/G2/G3 の 3 グループに分割し並列起動）による標準レビューループ（Codex 不要）。収束後の自動コミット・PR は codex 系と同じ |
 | `--claude-adv-review-loop`（`-cldarl`） | 独立 Opus の Breaker × Judge による敵対的レビューループ（Codex 不要）。収束後の自動コミット・PR は同上 |
@@ -37,7 +37,7 @@ GitHub Issue ID を受け取り、Issue を読み込んでブランチを作成�
 | 独立 QA | sonnet / high | 自己申告に依存しないテスト・lint の独立実行、受け入れ基準検証、自動コミット前の最終ゲート |
 | レビュワー / Judge（claude 系）・Breaker（両系統の敵対） | opus / max（Judge バッチのみ high。codex 敵対 Breaker〔雛形 C〕のみ sonnet / max） | コンテキスト隔離での diff レビュー / 裁定 / 反例生成（Breaker は codex 敵対モードでも使う。包括ラウンドのみ claude 標準レビュワーは観点を G1/G2/G3 の 3 グループに、claude 敵対 Breaker は攻撃観点を S/C/O の 3 レンズに分割して並列起動し以降は単発 1 体、Judge は反例を ≤4 件/バッチに分割し並列裁定） |
 | セキュリティ監査役 | opus / max（codex 系〔雛形 C〕のみ sonnet / max） | セキュリティ自動発動時に STRIDE・認可・データフロー観点を敵対的レビューへ注入（claude 系はレンズ S の Breaker に統合・codex 系は独立エージェント） |
-| レビュワー / Judge（codex 系） | Codex（別系統モデル） | `codex:rescue` 経由のレビュー・裁定（従来どおり） |
+| レビュワー / Judge（codex 系） | Codex（別系統モデル） | Claude Code ホストは `codex:rescue` 経由、Codex CLI ホストは `codex exec` の独立セッションでレビュー・裁定 |
 
 model はエイリアス指定（環境で利用可能な最新の同系統モデルに解決）。effort を指定できるのは Workflow ツールの `agent()` のみのため、エージェント起動はすべて Workflow ツールで行う。
 
@@ -55,7 +55,7 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 
 いずれのフラグでも、採用すべき指摘がなくなるまで「レビュー取得 → 妥当性判定（過剰対応チェック） → 修正 → テスト再実行」をループする（3 ラウンドごとに続行/打ち切り/中止をユーザーに確認）。**返ってきた指摘を採用するか（過剰対応でないか）の判定は、どのモードでもレビュイーの開発者エージェントが行う**。
 
-- **codex 標準（`-cdxrl`）**: Codex（`codex:rescue` 経由）が単独で diff をレビューする
+- **codex 標準（`-cdxrl`）**: Codex（Claude Code ホストは `codex:rescue` 経由、Codex CLI ホスト＝本 skill 自体を Codex CLI が実行している場合は `codex exec` の独立セッション）が単独で diff をレビューする
 - **codex 敵対（`-cdxarl`）**: Breaker（独立 Sonnet エージェント。実装文脈から隔離）× Codex=Judge（真の欠陥かノイズかを裁定）の二者構造。Workflow が使えない環境ではメインセッションが Breaker を代行する（従来動作）
 - **claude 標準（`-cldrl`）**: Opus（effort max）のレビュワーエージェントが diff をレビューする（観点は codex 標準と同一・union 不変）。包括ラウンド（初回セット round 1）のみ、観点を G1（仕様充足 / バグ / テストカバレッジ）/ G2（回帰 / データ整合性・性能 / 実装レベルの危険箇所）/ G3（運用・保守・可用性 / アーキテクチャ境界 / プロジェクト固有基準）の 3 グループに分割した並列レビュワーとして起動し、差分スコープのラウンド 2+ と確認ラウンドは単発 1 体（全 9 観点横断）で実施する（敵対 Breaker のレンズ分割と同型。一部グループ失敗は `reviewerDegraded` フラグで伝播）
 - **claude 敵対（`-cldarl`）**: Breaker × Judge を**別々の** Opus エージェントが担う。Breaker は包括ラウンドのみ攻撃観点を S（セキュリティ）/ C（正確性・データ）/ O（運用・保守）の 3 レンズに分割した並列エージェント（各 effort max。観点の union は従来の単一 Breaker と同一）として起動し、以降のラウンドは単発 1 体（全攻撃観点横断）で実施する。Judge は全レンズの反例を ≤4 件/バッチに分割し並列裁定（effort high。単一 Judge が多数シナリオの照合で無進捗ウォッチドッグにストールするのを防ぐ）。収束は dry-twice（連続 2 クリーンラウンド）。ラウンド 2 以降は直前ラウンドの採用修正差分に重点付けする（差分スコープ化）。裁定基準は codex Judge と同等。独立性はコンテキスト隔離 + 役割分離で担保（別系統モデルではないため、認証・決済・データスキーマ・外部 API などの重要変更には codex 系を推奨）
@@ -65,7 +65,7 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 - 敵対モードの裁定「仕様未定」（仕様が曖昧で要確認の指摘）は、対話できないエージェントに握り潰させず、オーケストレーターが AskUserQuestion でユーザーに確認して確定内容を context.md に反映する
 - 収束後の自動コミット・PR（フラグ明示時のみ）の前に、**独立 QA の最終ゲート**を通す（不合格なら自動コミットを中止して相談）。`smart-commit` / `smart-pr` は `disable-model-invocation` のため、コミット・push は `git`、PR 作成は GitHub MCP（不在時は `gh`）で直接実行する。機密ファイル警告・pre-commit hook・behind 時のマージ確認などの安全系は維持する
 - PR 本文のレビュアー向け補足に `🤖 Codex レビュー済み（…）` / `🤖 Claude レビュー済み（…）` / `🤖 Claude 敵対的レビュー済み（Breaker×Judge=独立 Opus…）` を記載する
-- `codex:rescue` が使えない環境では Claude がレビュー・裁定を代行せず、従来の完了案内（コミット・PR は手動）にフォールバックする（レビュー済み表記なし）。ただしセキュリティ自動発動のケースに限り claude 敵対レビューで代替する。claude 系が使えない（Workflow なし）場合も同様に代行せずフォールバックする
+- レビュー取得経路（`codex:rescue` / `codex exec`）が使えない環境では Claude がレビュー・裁定を代行せず、従来の完了案内（コミット・PR は手動）にフォールバックする（レビュー済み表記なし）。ただしセキュリティ自動発動のケースに限り claude 敵対レビューで代替する。claude 系が使えない（Workflow なし）場合も同様に代行せずフォールバックする
 - 実装とは独立に敵対的レビューだけ行いたい場合は `/code-reviewer-adversarial` を直接使う
 - claude 系レビューのレビュワー・Breaker・Judge プロンプトは `code-reviewer`（`--isolated`）・`code-reviewer-adversarial`（`--claude-judge`）へも移植されている（`smart-issue-plan` の `sip-plan-review-set` も同骨格の変種）。観点・裁定基準を変えるときは CLAUDE.md「スキル改修時の注意」の同期対象一覧（4 スキル）をすべて同期する
 
@@ -89,6 +89,6 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 - **git** — ブランチ作成・チェックアウトに使用
 - **GitHub MCP サーバー** — Issue の読み取りに必須（[GitHub MCP plugin](https://github.com/anthropics/claude-code-plugins/tree/main/github)）
 - **Workflow ツール（Claude Code 本体機能）** — 役割別エージェントのオーケストレーションと claude 系レビューループに必須。model / effort の明示指定（開発者 = opus/max、claude 系レビュワー = opus/max、独立 QA = sonnet/high 等）は Workflow の `agent()` でのみ可能。利用できない環境ではメインセッションの単一セッション実装に degrade する（claude 系レビューループは利用不可）
-- **Codex プラグイン（`codex:rescue` スキル）** — `--codex-review-loop` / `--codex-advs-review-loop` 使用時に必須。セキュリティ自動発動時は第一候補（不在なら claude 系で代替）
+- **Codex プラグイン（`codex:rescue` スキル）または Codex CLI（`codex exec`）** — `--codex-review-loop` / `--codex-advs-review-loop` 使用時に必須（Claude Code ホストは `codex:rescue` スキル、本 skill 自体を Codex CLI が実行している場合は `codex exec` が使えること）。セキュリティ自動発動時は第一候補（不在なら claude 系で代替）
 - **git + GitHub MCP（または gh）** — レビューループ収束後の自動コミット・PR 作成に使用（コミット・push は git、PR 作成は GitHub MCP を優先。`smart-commit` / `smart-pr` は `disable-model-invocation` のため自動呼び出し不可。手動起動は従来どおり可能）
 - **AskUserQuestion** — Issue 番号未指定時の確認、およびレビューループ 3 ラウンドごとの続行/打ち切り/中止の確認に使用（Claude Code 拡張。他エージェントではテキスト確認にフォールバック）

--- a/skills/smart-issue-resolve/SKILL.md
+++ b/skills/smart-issue-resolve/SKILL.md
@@ -33,7 +33,7 @@ GitHub Issue を起点に、ブランチ作成 → 役割別エージェント�
 | レビュワー（claude 標準） | Workflow エージェント | opus / max | diff レビュー（codex 標準と同一観点。包括ラウンド〔初回セット round 1〕のみ観点を G1/G2/G3 の 3 グループに分割し並列起動、以降のラウンドは単発 1 体〔全 9 観点横断〕。diff は正本ファイル `{作業Dir}/diff.md` を読む） |
 | Breaker / Judge（敵対） | Workflow エージェント | opus / max（Judge バッチのみ high。codex 系 Breaker〔雛形 C〕のみ sonnet / max） | 反例生成（Breaker・max。claude 系は包括ラウンドのみ攻撃観点を S/C/O の 3 レンズに分割し並列起動、以降は単発 1 体）と裁定（Judge・high。Breaker の反例を ≤4 件/バッチに分割し並列裁定）。コンテキスト隔離で実装文脈から独立（claude 系の diff は `{作業Dir}/diff.md` を読む） |
 | セキュリティ監査役 | Workflow エージェント | opus / max（codex 系〔雛形 C〕のみ sonnet / max） | セキュリティ自動発動時に STRIDE・認可・データフローの観点を敵対的レビューへ注入（claude 系〔雛形 B〕はレンズ S の Breaker に統合され初回ラウンドで監査を内蔵実施・codex 系〔雛形 C〕は独立エージェント） |
-| レビュワー / Judge（codex 系） | codex:rescue | -（別系統モデル） | Codex によるレビュー・裁定（従来どおり） |
+| レビュワー / Judge（codex 系） | Claude Code ホストは codex:rescue、Codex CLI ホストは codex exec | -（別系統モデル） | Codex によるレビュー・裁定 |
 
 - model はエイリアス指定（環境で利用可能な最新の同系統モデルに解決される）。effort を明示指定できるのは Workflow ツールの `agent()` のみのため、エージェント起動はすべて **Workflow ツール**で行う（本スキルの指示による呼び出しは Workflow の明示オプトインに該当する）
 - **Workflow ツールが使えない環境**（他エージェント・旧バージョン）では、オーケストレーションせずメインセッションが実装フローを直接実施する（従来動作への degradation。claude 系レビューループは利用不可 → フォールバック参照）
@@ -224,7 +224,7 @@ degraded 実装（Workflow 不能）の場合は「独立 QA・設計整合レ�
 セキュリティ影響ありと判定し、かつ `{レビューモード}` が `off` または `standard` の場合、`{レビューモード}` を `adversarial` に昇格させ、発動理由（検出したシグナル）をユーザーに 1 行で明示する。`{レビュー系統}` は次のとおり決める:
 
 - 系統フラグが明示されている → その系統のまま adversarial へ昇格
-- フラグ未指定（`off` からの自動発動） → `codex:rescue` が利用可能なら `codex`、利用不能なら `claude`（Workflow 必須）。両方利用不能ならフォールバック参照
+- フラグ未指定（`off` からの自動発動） → codex 系のレビュー取得経路（Claude Code ホストの `codex:rescue` / Codex CLI ホストの `codex exec`）のいずれかが利用可能なら `codex`、いずれも利用不能なら `claude`（Workflow 必須）。両方利用不能ならフォールバック参照
 
 > `{ループ明示}` = false（フラグ未指定でセキュリティ検出により発動）の場合、レビューは実施するが **収束後のコミット・PR 自動実行は行わない**（手順 7 の通常完了案内に切り替える）。外部への副作用（push・PR）を伴う自動化は明示オプトイン時のみ。
 
@@ -254,18 +254,23 @@ degraded 実装（Workflow 不能）の場合は「独立 QA・設計整合レ�
 **実行形態**:
 
 - **claude 系** — 骨格 1〜4 の 1 セット（最大 3 ラウンド）を雛形 B（sir-claude-review-set）の Workflow 1 回で実行する（収束時はセット内で最終 QA まで実施して返る）。**新規セットを起動する直前に必ず `bash {作業Dir}/gen-diff.sh origin/<デフォルトブランチ> <startRound>` を実行してレビュー正本 `{作業Dir}/diff.md` を生成する**（初回セット・継続セットのいずれも。生成しないとそのセットの round 1 でレビュー役が全員 git フォールバックに落ちる。ただし `resumeFromRunId` による同一セットの再開では生成しない — 再開後のスクリプトは進行済みの期待スタンプを保持しており、作り直すとスタンプが巻き戻って残りラウンドが不要にフォールバックする）。オーケストレーターは返却（`converged` / `records` / `specQuestions` / `cleanStreak`）を受けて、上限チェック（AskUserQuestion）と裁定「仕様未定」のユーザー確認を行い、確定した仕様は context.md（追加指示）へ追記する（修正が必要になれば未収束として続行）。続行なら `startRound` を +3、`priorSummary` に経緯要約 + 前セット最終ラウンドの採用修正内容（`records` 末尾の `adoptedItems`）を入れ、**返却の `cleanStreak` も引き継いで**同じ scriptPath で再起動する（ラウンド 2 以降の差分スコープと dry-twice の連続クリーン判定をセット跨ぎで連続させるため。再起動前の diff.md 再生成と `startedAt` の再実測も忘れない）
-- **codex 系** — オーケストレーターがラウンド単位で回す。レビュー・裁定は Skill ツールで `codex:rescue` を呼び（従来どおり）、敵対の Breaker は雛形 C、修正は雛形 D で行う。敵対の裁定に「仕様未定」が含まれる場合は、雛形 D に渡す前にオーケストレーターが AskUserQuestion でユーザーに仕様を確認し、確定内容を context.md（追加指示）へ追記する。雛形 D の起動前に、レビュー結果を `{作業Dir}/findings-round-<N>.md` に書き出す（標準: Codex の指摘全件、敵対: 裁定の真の欠陥 + 確定した仕様未定。要約・取捨選択をしない。物理ゲート: このファイルが無ければ起動しない）
+- **codex 系** — オーケストレーターがラウンド単位で回す。レビュー・裁定の取得はホストで分岐する（**Claude Code ホスト**は Skill ツールで `codex:rescue` を呼ぶ従来どおりの経路、**Codex CLI ホスト**＝本 skill 自体を Codex CLI が実行している場合は `codex exec` で独立した新規セッションを起動する経路。詳細は下記「標準モード」「敵対的モード」）。敵対の Breaker は雛形 C、修正は雛形 D で行う。敵対の裁定に「仕様未定」が含まれる場合は、雛形 D に渡す前にオーケストレーターが AskUserQuestion でユーザーに仕様を確認し、確定内容を context.md（追加指示）へ追記する。雛形 D の起動前に、レビュー結果を `{作業Dir}/findings-round-<N>.md` に書き出す（標準: Codex の指摘全件、敵対: 裁定の真の欠陥 + 確定した仕様未定。要約・取捨選択をしない。物理ゲート: このファイルが無ければ起動しない）
 
 #### 標準モード（codex 系: --codex-review-loop）
 
-[assets/codex-review-prompt.md](assets/codex-review-prompt.md) のテンプレートを埋め、Skill ツールで `codex:rescue` を呼び出す。Codex が単独で diff をレビューし、指摘を返す。返った指摘は雛形 D（開発者エージェント）で判定・反映する。
+[assets/codex-review-prompt.md](assets/codex-review-prompt.md) のテンプレートを埋め、レビューを取得する:
+
+- **Claude Code ホスト**（Skill ツールが使える）: Skill ツールで `codex:rescue` を呼び出す
+- **Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している。`codex:rescue` は Claude Code 専用のため存在しない）: `codex exec`（非対話・毎回新規セッション）を Bash から起動しテンプレートを渡す。実装を行っている現在のセッションとは独立した新規セッションでレビューを取得し、同一セッション内で自己レビューを完結させない（独立性が失われるため）
+
+Codex が単独で diff をレビューし、指摘を返す。返った指摘は雛形 D（開発者エージェント。Workflow 不能な degraded 環境ではメインセッションが代行）で判定・反映する。
 
 #### 敵対的モード（codex 系: --codex-advs-review-loop / セキュリティ自動発動）
 
 Breaker（独立 Sonnet エージェント）× Codex=Judge の二者構造でレビューする:
 
 1. **Breaker（雛形 C: sir-codex-breaker）** — 実装文脈から隔離された Sonnet（effort max）エージェントが、反例・攻撃シナリオ・不変条件違反を列挙する（攻撃観点・反例テストの規律はプロンプトに内蔵。反例テストは `.breaker-probe.` 命名の使い捨てとして扱う）。Workflow が使えない環境では、メインセッションが雛形 C の Breaker プロンプト（攻撃観点・反例テストの規律）を自身に適用して代行する（従来動作）
-2. **Judge（Codex）** — [assets/codex-judge-prompt.md](assets/codex-judge-prompt.md) のテンプレートに Breaker の反例リストと反例テストの実行結果を埋め、Skill ツールで `codex:rescue` を呼び出す。Codex は各反例を「真の欠陥 / 仕様未定 / 低優先度 / ノイズ」に裁定し、独立にも diff をレビューして追加の真の欠陥を挙げる
+2. **Judge（Codex）** — [assets/codex-judge-prompt.md](assets/codex-judge-prompt.md) のテンプレートに Breaker の反例リストと反例テストの実行結果を埋め、レビューを取得する。**Claude Code ホスト**では Skill ツールで `codex:rescue` を呼び出す。**Codex CLI ホスト**（`codex:rescue` が存在しない）では `codex exec` を Bash から起動し、Breaker（雛形 C、または代行しているメインセッション）とは独立した新規セッションで裁定させる。Codex は各反例を「真の欠陥 / 仕様未定 / 低優先度 / ノイズ」に裁定し、独立にも diff をレビューして追加の真の欠陥を挙げる
 3. Judge が「真の欠陥」「仕様未定」に分類した指摘を、共通骨格の手順 2（雛形 D）に渡す
 
 > **共犯化の回避**: Judge（Codex）の裁定を Claude が模擬・代行しない。裁定者（Codex）が別系統モデルであることが codex 系敵対レビューの核。
@@ -298,10 +303,10 @@ behind 時のマージ確認・競合対応は履歴に影響するため、自�
 
 ### フォールバック
 
-**codex 系（codex:rescue 利用不能時）** — 以下のいずれかに該当する場合:
+**codex 系（codex:rescue / codex exec が利用不能時）** — 以下のいずれかに該当する場合:
 
-- **呼び出し不能** — Codex プラグイン未導入・Codex CLI 未設定・他エージェント環境などで `codex:rescue` が呼び出せない
-- **復旧不能なハング** — 呼び出し済みのレビュー/裁定が返らず（silent death）、[assets/codex-review-prompt.md](assets/codex-review-prompt.md) の「運用ノート」に従った復旧（cancel → `--resume` 再投入）を 2 回試みても完了しない（ハング時は即フォールバックせず、必ず先に復旧を試みる）
+- **呼び出し不能** — レビュー取得の経路（Claude Code ホストの `codex:rescue` / Codex CLI ホストの `codex exec`）が使えない。具体的には: Claude Code ホストで Codex プラグイン未導入・Codex CLI 未設定により `codex:rescue` が呼び出せない、Codex CLI ホストで `codex` バイナリが未インストール・未認証などで `codex exec` の実行に失敗する、またはそれ以外のエージェント環境でいずれの経路も提供されない
+- **復旧不能なハング** — 呼び出し済みのレビュー/裁定が返らず（silent death）、[assets/codex-review-prompt.md](assets/codex-review-prompt.md) の「運用ノート」に従った復旧（cancel → `--resume` 再投入）を 2 回試みても完了しない（ハング時は即フォールバックせず、必ず先に復旧を試みる。Codex CLI ホストの `codex exec` はジョブレジストリを持たない同期呼び出しのため、この複雑な復旧手順は対象外 — 単純にタイムアウト・失敗として「呼び出し不能」に倒す）
 
 該当した場合:
 

--- a/skills/smart-issue-resolve/assets/codex-judge-prompt.md
+++ b/skills/smart-issue-resolve/assets/codex-judge-prompt.md
@@ -1,10 +1,10 @@
 # Codex Judge 依頼テンプレート（敵対的モード・実装コード）
 
-敵対的モード（`--codex-advs-review-loop` / セキュリティ自動発動）のループで、Breaker（独立 Sonnet エージェント。Workflow 不能時はメインセッションが代行）が生成した反例を Codex（Judge）に裁定させる依頼文のテンプレート。`<>` を埋めて `codex:rescue` に task として渡す。標準モードのレビュー依頼は [codex-review-prompt.md](codex-review-prompt.md) を使う。
+敵対的モード（`--codex-advs-review-loop` / セキュリティ自動発動）のループで、Breaker（独立 Sonnet エージェント。Workflow 不能時はメインセッションが代行）が生成した反例を Codex（Judge）に裁定させる依頼文のテンプレート。`<>` を埋めて、**Claude Code ホスト**では `codex:rescue` へ task として渡し、**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している場合。`codex:rescue` は存在しない）では `codex exec` の入力として渡す。標準モードのレビュー依頼は [codex-review-prompt.md](codex-review-prompt.md) を使う。
 
 ---
 
-## codex:rescue への依頼文テンプレート
+## Codex への依頼文テンプレート（codex:rescue / codex exec 共通）
 
 ```
 あなたは GitHub Issue 対応の実装コードの Judge（裁定者）として振る舞う。
@@ -78,11 +78,11 @@ Breaker に迎合せず、独立した視点で判断すること。
 
 ## 呼び出し時の注意
 
-- このテンプレート全体を埋めたうえで、Skill ツールの `codex:rescue` に task として渡す
+- このテンプレート全体を埋めたうえで渡す。**Claude Code ホスト**では Skill ツールの `codex:rescue` に task として渡す。**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している。`codex:rescue` は存在しない）では `codex exec`（例: `codex exec --sandbox read-only -C <リポジトリルート> -` で stdin からテンプレートを読ませる。裁定のみでファイル変更をさせないため `--sandbox read-only` を明示する）を Bash から起動する。いずれの経路でも、Breaker を実施したセッションとは独立した新規セッションで裁定させる
 - Codex はリポジトリにアクセスできるため、diff の取得・コードの確認・反例の照合は Codex 側に行わせる（巨大な diff や反例テスト全文を依頼文に貼り込まない。要点のみ）
 - Codex にコードの修正を行わせない（裁定のみ）。修正は Claude 側の妥当性判定（過剰対応チェック）を経てから行う
 - 返ってきた裁定の再解釈・要約による弱体化をしない（妥当性判定は採用 / 不採用の分類と理由の明記のみ）
 
 ## 運用ノート: silent death（ハング・静止死）からの復旧
 
-silent death の検知・回収・復旧（cancel → `--resume` 再投入）・予防の手順は [codex-review-prompt.md](codex-review-prompt.md) の「運用ノート」に従う。復旧を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue 利用不能時）」に切り替える。
+silent death の検知・回収・復旧（cancel → `--resume` 再投入）・予防の手順（Claude Code ホスト / codex:rescue 経由）、および Codex CLI ホストでの補足は [codex-review-prompt.md](codex-review-prompt.md) の「運用ノート」に従う。復旧を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue / codex exec が利用不能時）」に切り替える。

--- a/skills/smart-issue-resolve/assets/codex-review-prompt.md
+++ b/skills/smart-issue-resolve/assets/codex-review-prompt.md
@@ -1,10 +1,10 @@
 # Codex レビュー依頼テンプレート（実装コード）
 
-標準モード（`--codex-review-loop`）のループ手順 1 で `codex:rescue` に渡す依頼文のテンプレート。`<>` を埋めて task として渡す。敵対的モード（`--codex-advs-review-loop`）の Judge 依頼は [codex-judge-prompt.md](codex-judge-prompt.md) を使う。
+標準モード（`--codex-review-loop`）のループ手順 1 でレビューを取得する依頼文のテンプレート。`<>` を埋めて、**Claude Code ホスト**では `codex:rescue` へ task として渡し、**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している場合。`codex:rescue` は存在しない）では `codex exec` の入力として渡す。敵対的モード（`--codex-advs-review-loop`）の Judge 依頼は [codex-judge-prompt.md](codex-judge-prompt.md) を使う。
 
 ---
 
-## codex:rescue への依頼文テンプレート
+## Codex への依頼文テンプレート（codex:rescue / codex exec 共通）
 
 ```
 あなたは GitHub Issue 対応の実装コードのレビュアーとして振る舞う。
@@ -67,12 +67,12 @@
 
 ## 呼び出し時の注意
 
-- このテンプレート全体を埋めたうえで、Skill ツールの `codex:rescue` に task として渡す
+- このテンプレート全体を埋めたうえで渡す。**Claude Code ホスト**では Skill ツールの `codex:rescue` に task として渡す。**Codex CLI ホスト**（本 skill 自体を Codex CLI が実行している。`codex:rescue` は存在しない）では `codex exec`（非対話・毎回新規セッション。例: `codex exec --sandbox read-only -C <リポジトリルート> -` で stdin からテンプレートを読ませる。レビューのみでファイル変更をさせないため `--sandbox read-only` を明示する）を Bash から起動する。いずれの経路でも、実装を行っている現在のセッションとは独立した新規セッションでレビューを取得し、同一セッション内で自己レビューを完結させない
 - Codex はリポジトリにアクセスできるため、diff の取得・コードの確認は Codex 側に行わせる（巨大な diff を依頼文に貼り込まない）
 - Codex にコードの修正を行わせない（レビューのみ）。修正は Claude 側の妥当性判定を経てから行う
 - 返ってきた指摘の再解釈・要約による弱体化をしない（妥当性判定は採用 / 不採用の分類と理由の明記のみ）
 
-## 運用ノート: silent death（ハング・静止死）からの復旧
+## 運用ノート: silent death（ハング・静止死）からの復旧（Claude Code ホスト / codex:rescue 経由）
 
 Codex のレビュープロセスは、ジョブレジストリ上 `running` のまま静かに死ぬことがある。レビュー結果がいつまでも返らない場合は、フォールバックに切り替える前に以下の順で復旧を試みる:
 
@@ -81,4 +81,8 @@ Codex のレビュープロセスは、ジョブレジストリ上 `running` の
 3. **復旧（resume が最効率）** — companion の cancel（`/codex:cancel`）で stale ジョブを落とす → resume 候補が復活する（`task-resume-candidate` が `available: true` を返す）→ `--resume` を付けて `codex:rescue` を再投入する。調査コンテキストを引き継いで続きから実行されるため、fresh 再実行より大幅に速い
 4. **予防** — companion を Bash で直接起動する経路では timeout を 600000ms（10 分）に明示する（デフォルト 120 秒では長いレビューが親側から切られる）。長時間が見込まれるレビューは `--background` 実行でプロセスのライフサイクルを呼び出し元の Bash から切り離すことを検討する
 
-復旧（cancel → `--resume` 再投入）を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue 利用不能時）」に切り替える。
+復旧（cancel → `--resume` 再投入）を 2 回試しても完了しない場合は、SKILL.md の「フォールバック（codex:rescue / codex exec が利用不能時）」に切り替える。
+
+## Codex CLI ホストでの補足
+
+`codex exec` は呼び出し元の Bash（Codex CLI 自身が実行する shell）内で同期的に完了を待つ同期呼び出しで、上記の companion 側ジョブレジストリによる stall 検知・復旧手順の対象外である（`codex exec` 自体のセッション記録の有無は関知しない。復旧手段として使えるのは `codex exec resume` 程度）。長いレビューでタイムアウトしないよう呼び出し側の Bash の timeout を十分に長く取り、それでも応答がなく完了しない場合は複雑な復旧手順を適用せず、そのまま「フォールバック（codex:rescue / codex exec が利用不能時）」に切り替える。


### PR DESCRIPTION
## 概要

`smart-issue-resolve` / `smart-issue-plan` の codex レビューオプション（`-cdxrl` / `-cdxarl`）は、常に Claude Code 専用の Skill ツール `codex:rescue` を呼んでレビューを取得していた。しかしこの2スキルは `npx skills` によるクロスツール配布対象であり、**skill 自体が Codex CLI をホストとして実行される場合**（`codex:rescue` が存在しない環境）ではレビュー取得経路がなく機能しなかった。ホストに応じて経路を分岐させ、Codex CLI ホストでも独立したレビューを取得できるようにする。

## 実装内容

| スキル | 変更ファイル | 内容 |
|---|---|---|
| smart-issue-resolve | `SKILL.md` | 標準/敵対的モードのレビュー取得手順・役割表・自動発動時の系統選択・フォールバック条件にホスト分岐を追記 |
| smart-issue-resolve | `README.md` | オプション表・役割表・前提条件をホスト分岐に同期 |
| smart-issue-resolve | `assets/codex-review-prompt.md` / `codex-judge-prompt.md` | 呼び出し手順・運用ノートにホスト分岐、Codex CLI ホスト向け補足を追加 |
| smart-issue-plan | 上記4ファイルと同型の変更 | smart-issue-plan は resolve と意図的に近似構成のため同一パターンで同期 |

**ホスト分岐の内容**:

| ホスト | レビュー取得経路 |
|---|---|
| Claude Code | 従来どおり Skill ツールで `codex:rescue` を呼ぶ |
| Codex CLI（本 skill 自体を Codex CLI が実行） | `codex exec --sandbox read-only -C <リポジトリルート> -`（非対話・毎回新規セッション）を Bash から起動し、実装/計画を行っている現在のセッションとは独立した新規セッションでレビューを取得する |

## 設計判断（要点）

### 採用した方針

| 観点 | 採用案 | 理由 |
|---|---|---|
| 分岐の粒度 | Claude Code ホスト / Codex CLI ホストの2分岐のみ | 本リポジトリの CLAUDE.md が既にクロスツール配布（`npx skills`）を前提としており、Codex CLI ホストは実在するシナリオ |
| Codex CLI 側の実行コマンド | `codex exec`（非対話・毎回新規セッション） | `codex --help` / `codex exec --help` で実在を確認済み。同一セッション内での自己レビューを避け、独立性を保つのが目的のため「新規セッション」であることが必須 |
| サンドボックス指定 | `--sandbox read-only` を明示 | レビュー専用呼び出しでファイル変更をさせないため（`codex exec` にデフォルト値の明記がなかったため明示が必要と判断） |
| silent death 復旧手順 | Claude Code ホスト（companion のジョブレジストリ）専用のまま維持し、Codex CLI ホストは単純タイムアウト＋フォールバックに簡略化 | `codex exec` は呼び出し元 Bash 内の同期呼び出しでジョブレジストリを持たないため、既存の複雑な復旧手順（cancel → resume）を適用する対象ではない |

### 未対応（follow-up）

なし（スコープが自己完結する変更のため）

## レビュースコープ

**重点レビュー**:
- ホスト分岐の判定条件（Claude Code ホスト vs Codex CLI ホスト）に読み違えの余地がないか
- `smart-issue-resolve` と `smart-issue-plan` 間の記述の同期漏れがないか（意図的な二重化ペア）

**対象外**:
- Workflow ベースの claude 系レビューループ（`-cldrl` / `-cldarl`）は本 PR の変更対象外

## 動作確認

- `codex --help` / `codex exec --help` を実行し、`codex exec` サブコマンドおよび `--sandbox` / `-C` / `--ephemeral` オプションの実在を確認済み
- `codex:rescue`（Skill ツール経由の独立 Codex セッション）に本変更の diff を渡し、プロンプト品質観点でレビューを実施。指摘（README・役割表の分岐漏れ、自動発動時の系統判定ロジックの穴、`codex exec` 呼び出しの sandbox 未指定、rollout transcript に関する言い過ぎ）はすべて反映済み
- 未実施: Codex CLI を実際のホストとして本 skill を動かす統合的な動作確認（このリポジトリの開発環境では検証手段がなく、記述レベルの整合性確認に留まる）

## 備考

- 8ファイルとも markdown のスキル指示ファイルであり、コード変更・テストは含まない
- 関連する Issue は検索したが見つからなかった（近い Issue #70 は別件でクローズ済み）ため Issue 紐付けなし
