### PR TITLE
feat(smart-issue-resolve): worktree で作業する -wt/--worktree オプションを追加

### DIFF
--- a/docs/implementation-notes/2026-08-01-sir-worktree-option.md
+++ b/docs/implementation-notes/2026-08-01-sir-worktree-option.md
@@ -1,0 +1,52 @@
+# smart-issue-resolve: -wt/--worktree オプション 実装ノート
+
+- 日付: 2026-08-01（JST）
+- 依頼: smart-issue-resolve スキルに、worktree での作業を指示する `-wt` / `--worktree` オプションを追加する
+- 設計スペック: なし（口頭依頼をそのまま実装。実装前に advisor でアーキテクチャレビューを実施）
+- 実行方法: メインセッションでの直接実装（brainstorming 等の別スキルは未使用。既存スキルへの小規模なオプション追加のため）
+
+## 変更内容
+
+- `skills/smart-issue-resolve/SKILL.md`:
+  - frontmatter（description・argument-hint・`allowed-tools` に `EnterWorktree` を追加）
+  - 「引数の解析」に `--worktree`/`-wt` の解析ルールを追加
+  - 手順3（作業ツリーの状態確認）: `{worktree}` = true のとき stash 判定・退避を丸ごとスキップする分岐を追加
+  - 手順5（ブランチ作成・チェックアウト）: `{worktree}` = true のとき `.claude/worktrees/<ブランチ名>` に `git worktree add` でブランチを作成し、`EnterWorktree({ path })` でセッションを切り替えるフローを追加
+  - 手順7（完了案内）・「収束後のコミット・PR 作成」・「注意事項」: worktree パスの案内、`ExitWorktree` を本スキルからは呼ばない旨、`/smart-git-sync` へのクリーンアップ委譲を追記
+- `skills/smart-issue-resolve/README.md`: 使い方・オプション表・フロー・関連スキル・前提条件を同期
+
+## 仕様に明記されていなかったため自分で判断した事項
+
+1. **`EnterWorktree` は常に `path` 指定で呼ぶ（`name` は使わない）**: `name` 指定での新規作成は「セッションが既に worktree にいる場合は使えない」という制約があるが、`path` 指定での切り替えはその制約を受けない。また `name` 指定は起点ブランチが `worktree.baseRef` 設定（既定 `fresh` = 最新の `origin/<デフォルトブランチ>`、`head` = 現在の HEAD）に依存し、環境のカスタム設定次第で本スキルの既存の「最新デフォルトブランチから分岐する」という前提が崩れうる。そこで常に `git worktree add ... origin/<デフォルトブランチ>`（または既存ブランチ）を自前で実行してから `EnterWorktree({ path })` で切り替える設計にした。挙動が設定に依存せず、非 worktree モードの手順5とロジックを揃えられる
+2. **`ExitWorktree` は本スキルから呼ばない**: ツール自身の説明に「ユーザーが明示的に求めたときのみ呼ぶ」と明記されているため、完了時も呼ばずセッションを worktree に留める。完了案内で worktree パスと「元に戻るには `ExitWorktree({ action: "keep" })` か新規セッション」を明示することで代替した
+3. **worktree・ブランチの削除は `/smart-git-sync` に委譲し、本スキルには実装しない**: `smart-git-sync` が直近（2026-07-31）で worktree 連携のクリーンアップ機能を実装済みのため、二重実装を避けて既存機能に一本化した
+4. **worktree パスは `{メインルート}/.claude/worktrees/<ブランチ名>` に固定（メインルート起点）**: `EnterWorktree` が `path` で切り替え可能な worktree に課す制約（"the target must be a worktree under `.claude/worktrees/` of the same repository"）を満たすため。当初はカレントディレクトリからの相対パス `.claude/worktrees/<ブランチ名>` で書いていたが、セッションが既に別の linked worktree にいる場合は相対パスがその worktree 内に解決されてしまい、(a) 入れ子 worktree になり上記制約を満たせない、(b) linked worktree では `.git` がファイルであり `.git/info/exclude` への追記がそのまま失敗する、という 2 つの不具合を advisor 指摘で実機確認した。`git worktree list --porcelain | head -1` で得るメイン worktree の絶対パスを起点にし、除外ファイルの追記先も `git rev-parse --git-common-dir`（main tree・linked worktree のどちらからでも共有 `.git` を正しく指す）に切り替えて解消した
+5. **`{作業Dir}`（レビュー・context.md 用の一時ディレクトリ）は worktree の有無に関わらず `mktemp` の OS 一時領域のまま**: worktree 内に置く設計も検討したが、レビュー成果物をコードの worktree に混在させない現行方針（`/tmp` 配下）をそのまま踏襲した方が、`{worktree}` = false のときと差分が生まれず単純
+6. **`smart-spec-to-pr` の転送語彙同期はスコープ外**: CLAUDE.md の同期ルールは smart-issue-resolve のレビューループフラグ名（`-cdxrl` 等）に限定されており、`-wt` は対象外。ユーザーからの依頼も本スキル単体だったため、`smart-spec-to-pr` 側は今回変更していない（advisor 指摘を受けての明示的なスコープ判断）
+
+## トレードオフの選択
+
+- **`.git/info/exclude` へのローカル追記**: `git worktree add .claude/worktrees/<name>` は、対象リポジトリの `.gitignore` に `.claude/` 除外が無い場合、`.claude/` ディレクトリが `git status` に未追跡として現れる（実機検証で確認）。追跡対象の `.gitignore`（コミットされ他の開発者にも影響する）を勝手に書き換えるのは越権と判断し、ローカル限定の `.git/info/exclude`（正確には `git rev-parse --git-common-dir` が指す共有 `.git` の `info/exclude`）に `.claude/worktrees/` を追記する方式にした（既に無視されていれば `git check-ignore` で検知しスキップ）
+- **既存ブランチの worktree 化が別ツリーで衝突する場合はエラーで停止**: `git worktree add` は対象ブランチが既に他の worktree（現在の作業ツリーを含む）でチェックアウト中だと失敗する。自動でリカバリ（強制解除等）はせず、「`-wt` を外すか、そちらの作業ツリー側で作業してください」と案内して停止する設計にした。ブランチの二重チェックアウト状態を無断で解消するのは safety 面で望ましくないため
+- **Workflow エージェントの cwd 継承は事前に実機検証で確認**: Workflow エージェントが post-EnterWorktree の cwd を継承するかは未文書化だったため、使い捨ての worktree を作って 1 エージェントの Workflow（`pwd && git branch --show-current`）を実行し、オーケストレーターと同じ cwd・ブランチを返すことを確認してから実装した（継承されない場合は `references/agent-orchestration.md` の全雛形に cwd 明示指示を追加する必要があったが、不要と判明した）
+- **worktree パスはメイン worktree 起点の絶対パスに固定**: 当初はカレントディレクトリからの相対パス `.claude/worktrees/<ブランチ名>` で書いていたが、セッションが既に別の linked worktree にいる場合に相対パスがその worktree 内へ解決されてしまい、(a) 入れ子 worktree になり `EnterWorktree` の「切り替え先は同一リポジトリの `.claude/worktrees/` 配下」という制約を満たせない、(b) linked worktree では `.git` がファイルであり `.git/info/exclude` への素朴な追記がそのまま失敗する、という 2 つの不具合を実機検証で確認した。`git worktree list --porcelain | head -1` で得るメイン worktree の絶対パスを起点にし、除外ファイルの追記先も `git rev-parse --git-common-dir`（main tree・linked worktree のどちらからでも共有 `.git` を正しく指す）に切り替えて解消した
+- **`smart-spec-to-pr` の転送語彙同期はスコープ外**: CLAUDE.md の同期ルールは smart-issue-resolve のレビューループフラグ名（`-cdxrl` 等）に限定されており、`-wt` は対象外。ユーザーからの依頼も本スキル単体だったため、`smart-spec-to-pr` 側は今回変更していない（意図的なスコープ限定）
+
+## 実装中に発見し修正した記述ミス
+
+- `git check-ignore -q <path>` は、対象パスが `.gitignore`/`exclude` 側でディレクトリ限定パターン（末尾 `/`）にしか一致しない場合、**クエリ側にも末尾 `/` が無いと** ディレクトリが未作成の間は「無視されていない」と誤判定する（末尾 `/` を付けるか、配下のダミーファイルパスを渡せば未作成でも正しく判定できる）ことを実機検証で発見した。SKILL.md 手順5の当初案は `git check-ignore -q .claude/worktrees`（末尾 `/` 無し）だったため、worktree 未作成の初回実行時に必ず「無視されていない」と誤判定して不要な追記を行う欠陥があった。`git check-ignore -q .claude/worktrees/`（末尾 `/` 付き）に修正し、両パターン（付き/無し・ディレクトリ作成前後）を実機で再検証した
+- ブランチ名にスラッシュを含むケース（本スキルの命名規則 `{type}/issue-{番号}-{説明}` の実際の形）を未検証のまま書いていた。`git worktree add -b feature/issue-1-x .claude/worktrees/feature/issue-1-x HEAD` を実機実行し、中間ディレクトリが自動作成されて正常に動作することを確認した（修正不要と判明）
+- worktree モードの分岐（手順5）が `origin/<デフォルトブランチ>` から直接分岐するにもかかわらず、`git fetch` を明示していなかった。非 worktree モードは「デフォルトブランチを最新にしてから」という共通の前置き文がある一方、実際にリモート参照を更新するコマンドがどこにも書かれていなかったため、両モードに影響する前置き文自体に `git fetch` を明記する形で修正した（worktree モードでの「古い `origin/main` から静かに分岐する」という実害が大きいシナリオを解消）
+
+## 検証
+
+- `bash -n` 等の構文チェック対象なし（SKILL.md/README.md のみの変更）
+- 実機検証（使い捨て worktree・使い捨て git リポジトリ）:
+  - `EnterWorktree({ name })` → セッション cwd が worktree に切り替わることを `pwd`/`git branch --show-current` で確認
+  - 上記 worktree 内で 1 エージェントの Workflow を実行し、エージェントの `pwd`/`git branch --show-current` がオーケストレーターと一致することを確認（cwd 継承の実証）
+  - 本リポジトリで手動 `git worktree add .claude/worktrees/<name>` を実行し、`git status --porcelain` が汚染されないこと（本リポジトリは既存の `.git/info/exclude` により無汚染）を確認
+  - 素の一時 git リポジトリ（`.git/info/exclude` に事前設定なし）で同じ手動 `git worktree add` を行い、`.claude/` が `git status --porcelain` に `?? .claude/` として現れることを確認（除外追記が必要なケースの再現）
+  - `git worktree add -b <branch> <path> <commit-ish>`（新規ブランチ・スラッシュ含みブランチ名でも）・`git worktree add <path> <branch>`（既存ブランチ）・衝突時のエラーメッセージ（`fatal: '<branch>' is already used by worktree at '<path>'`）・`git check-ignore -q <path>/` の判定ロジックを、それぞれ使い捨て git リポジトリで個別に実行して SKILL.md 記載どおりに動作することを確認
+  - linked worktree 内から `git worktree list --porcelain | head -1 | cut -d' ' -f2-` でメインルートを取得し、そこを起点に新規 worktree を作成すると（linked worktree の中に入れ子にならず）メインルート直下の `.claude/worktrees/` に正しく作られることを確認。`git -C "$ROOT" check-ignore -q .claude/worktrees/` と `$(git rev-parse --git-common-dir)/info/exclude` への追記も、linked worktree 内・main tree 内の両方から実行して動作することを確認
+  - 検証用の worktree・一時リポジトリはすべて `ExitWorktree({ action: "remove" })` または `rm -rf` で後始末済み
+- SKILL.md の行数: 379 行（500 行ガイドライン内）

--- a/skills/smart-issue-resolve/README.md
+++ b/skills/smart-issue-resolve/README.md
@@ -7,6 +7,7 @@ GitHub Issue ID を受け取り、Issue を読み込んでブランチを作成�
 ```
 /smart-issue-resolve #134
 /smart-issue-resolve #134 -p テストも書いて
+/smart-issue-resolve #134 --worktree              # または -wt（現在の作業ツリーを変更せず git worktree で作業）
 /smart-issue-resolve #134 --codex-review-loop     # または -cdxrl
 /smart-issue-resolve #134 --codex-advs-review-loop # または -cdxarl（敵対的レビュー・Judge=Codex）
 /smart-issue-resolve #134 --claude-review-loop     # または -cldrl（Opus レビュワー・包括ラウンドは観点3グループ並列）
@@ -20,6 +21,7 @@ GitHub Issue ID を受け取り、Issue を読み込んでブランチを作成�
 | オプション        | 説明                                     |
 | ----------------- | ---------------------------------------- |
 | `-p <プロンプト>` | 作業に関する追加指示（実装方針・制約等） |
+| `--worktree`（`-wt`） | 現在の作業ツリーを変更せず、git worktree（`.claude/worktrees/<ブランチ名>`。Claude Code の EnterWorktree ツールで切り替え）に分離した作業ディレクトリでブランチ作成から実装まで行う。未コミット変更があっても stash せず現在の作業ツリーに残したまま着手できる。完了後もセッションは worktree に留まる（`ExitWorktree` は本スキルからは呼ばない）。worktree・ブランチの削除は `/smart-git-sync` に任せる |
 | `--codex-review-loop`（`-cdxrl`） | 実装後に Codex 標準レビューループを実施し、収束後にコミット・PR 作成まで自動で行う（Claude Code + Codex プラグイン環境、または Codex CLI ホスト〔本 skill 自体を Codex CLI が実行している場合〕で `codex exec` が使える環境が前提） |
 | `--codex-advs-review-loop`（`-cdxarl`） | Breaker（独立 Sonnet）× Codex=Judge の敵対的レビューループ。収束後の自動コミット・PR は標準と同じ |
 | `--claude-review-loop`（`-cldrl`） | Opus レビュワーエージェント（包括ラウンドのみ観点を G1/G2/G3 の 3 グループに分割し並列起動）による標準レビューループ（Codex 不要）。収束後の自動コミット・PR は codex 系と同じ |
@@ -45,8 +47,8 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 
 1. Issue を読み取り、内容を把握する
 2. 既存の実装計画（`/smart-issue-plan` が作成したコメント or `[実装計画]` Issue）があれば参照し、計画記録の分析時点 SHA と最新デフォルトブランチの差分から陳腐化を検出する（古ければ計画更新を提案）
-3. 作業ツリーの状態を確認する（未コミット変更は識別可能なメッセージ付きで stash）
-4. Issue に基づいたブランチを作成・チェックアウトする
+3. 作業ツリーの状態を確認する（未コミット変更は識別可能なメッセージ付きで stash。`--worktree`/`-wt` 指定時は現在の作業ツリーに触れないため stash 不要）
+4. Issue に基づいたブランチを作成・チェックアウトする（`--worktree`/`-wt` 指定時は `.claude/worktrees/<ブランチ名>` に分離した worktree でブランチを作成し、EnterWorktree でセッションをそこへ切り替える）
 5. プロジェクト固有基準を収集し、一時作業ディレクトリに context.md（要件・計画・テスト方針・基準）を書き出す
 6. 実装 Workflow を起動する: 設計役（計画が無い/粗い場合）→ 開発者（ベースライン→実装→動作確認）→ 独立 QA（不合格なら開発者が修正、最大 2 回）→ 設計役の事後レビュー（設計整合・保守性・可用性）→ 反映 → QA 再確認
 7. レビューループ指定時（またはセキュリティ自動発動時）はレビューループへ。それ以外は変更サマリを提示して `/smart-commit` の使用を提案する（勝手にコミット・push しない）
@@ -77,6 +79,7 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 - `/smart-pr` — PR の作成・更新（同上）
 - `/code-reviewer-adversarial` — 実装から独立して敵対的レビューだけ回したいときに直接使う
 - `/codex:adversarial-review` — Codex 単独の敵対レビューをコード diff に単発でかけたいときに直接使う（Codex プラグイン付属。対象は git diff のみで計画テキストは対象外。本スキルのループには `disable-model-invocation` のため組み込めない）
+- `/smart-git-sync` — `--worktree`/`-wt` で作った worktree がマージ済みになったあと、ブランチと紐づく worktree をまとめて削除するときに使う
 
 ## 推奨: 新規セッションで実行する
 
@@ -89,6 +92,7 @@ model はエイリアス指定（環境で利用可能な最新の同系統モ�
 
 - **git** — ブランチ作成・チェックアウトに使用
 - **GitHub MCP サーバー** — Issue の読み取りに必須（[GitHub MCP plugin](https://github.com/anthropics/claude-code-plugins/tree/main/github)）
+- **EnterWorktree ツール（Claude Code 本体機能）** — `--worktree`/`-wt` 使用時に必須。利用できない環境（他エージェント）では通常のブランチ作成にフォールグレードする
 - **Workflow ツール（Claude Code 本体機能）** — 役割別エージェントのオーケストレーションと claude 系レビューループに必須。model / effort の明示指定（開発者 = opus/max、claude 系レビュワー = opus/max、独立 QA = sonnet/high 等）は Workflow の `agent()` でのみ可能。利用できない環境ではメインセッションの単一セッション実装に degrade する（claude 系レビューループは利用不可）
 - **Codex プラグイン（`codex:rescue` スキル）または Codex CLI（`codex exec`）** — `--codex-review-loop` / `--codex-advs-review-loop` 使用時に必須（Claude Code ホストは `codex:rescue` スキル、本 skill 自体を Codex CLI が実行している場合は `codex exec` が使えること。後者はホストのコマンドサンドボックス内では起動できないため、サンドボックス外での昇格実行の承認が必要）。セキュリティ自動発動時は第一候補（不在なら claude 系で代替）
 - **git + GitHub MCP（または gh）** — レビューループ収束後の自動コミット・PR 作成に使用（コミット・push は git、PR 作成は GitHub MCP を優先。`smart-commit` / `smart-pr` は `disable-model-invocation` のため自動呼び出し不可。手動起動は従来どおり可能）

--- a/skills/smart-issue-resolve/SKILL.md
+++ b/skills/smart-issue-resolve/SKILL.md
@@ -8,14 +8,15 @@ description: >
   作業完了後に smart-commit の使用を提案する（勝手にコミット・push はしない）。
   ユーザーが「Issue やって」「#123 に取り掛かる」「/smart-issue-resolve #123」と言ったら起動する。
   smart-issue-plan（計画のみ作成）とは別物。実装まで踏み込むときに使う。
+  --worktree（-wt）を付けると、現在の作業ツリーを変更せず git worktree（EnterWorktree）に分離した作業ディレクトリでブランチ作成から実装まで行う。
   --codex-review-loop（-cdxrl）を付けると実装後に Codex レビューループを実施し、収束後にコミット・PR 作成まで自動で行う。
   --codex-advs-review-loop（-cdxarl）は Breaker（独立 Sonnet）× Codex=Judge の敵対的レビューループを回す。
   --claude-review-loop（-cldrl）は Opus レビュワーエージェント（包括ラウンドのみ観点を G1/G2/G3 の 3 グループに分割し並列起動）による標準レビューループ、
   --claude-adv-review-loop（-cldarl）は独立 Opus の Breaker × Judge による敵対的レビューループを回す（Codex 不要）。
   認証・個人情報・決済などセキュリティ影響を検出した場合は、フラグ未指定でも敵対的レビューを自動発動する（Codex 不在環境では claude 系で代替）。
 disable-model-invocation: true
-argument-hint: "#issue-number [-p 追加指示] [--codex-review-loop|-cdxrl] [--codex-advs-review-loop|-cdxarl] [--claude-review-loop|-cldrl] [--claude-adv-review-loop|-cldarl]"
-allowed-tools: Read, Bash, Glob, Grep, Edit, Write, AskUserQuestion, Skill, Workflow
+argument-hint: "#issue-number [-p 追加指示] [-wt|--worktree] [--codex-review-loop|-cdxrl] [--codex-advs-review-loop|-cdxarl] [--claude-review-loop|-cldrl] [--claude-adv-review-loop|-cldarl]"
+allowed-tools: Read, Bash, Glob, Grep, Edit, Write, AskUserQuestion, Skill, Workflow, EnterWorktree
 ---
 
 # Smart Issue Resolve
@@ -53,6 +54,9 @@ GitHub Issue を起点に、ブランチ作成 → 役割別エージェント�
   - どれも無ければ `{レビューモード}` は `off`
   - いずれかのフラグが明示指定された場合は `{ループ明示}` = true を立てる（収束後のコミット・PR 自動実行の可否に使う）
   - 旧 `-codex-loop`（ハイフン 1 つ）を検出した場合は、`--codex-review-loop`（`-cdxrl`）／敵対的レビューなら `--codex-advs-review-loop`（`-cdxarl`）にリネームされた旨を案内して処理を止め、再指定を促す（旧フラグを Issue 番号の一部として解釈しない）
+- worktree フラグ（位置は問わない。レビューループのフラグと同じパスで該当トークンを除去する。`-p` の前後分割より前に処理する — 後回しにすると `-p` の追加指示に紛れ込む）:
+  - `--worktree` または `-wt` → `{worktree}` = true（現在の作業ツリーを変更せず、git worktree に分離した作業ディレクトリでブランチ作成から実装まで行う。詳細は手順 3・5）
+  - 無ければ `{worktree}` = false（既定。従来どおり現在の作業ツリーで直接ブランチを作成する）
 - `-p` より前の部分 → Issue 番号（`#` は除去）
 - `-p` より後の部分 → `{プロンプト}`（実装方針・制約に関する追加指示）
 - `-p` がない場合 → 残り全体を Issue 番号として扱い、`{プロンプト}` は空
@@ -62,6 +66,7 @@ GitHub Issue を起点に、ブランチ作成 → 役割別エージェント�
 例: `/smart-issue-resolve #42 --codex-review-loop` → レビューモード: standard、系統: codex
 例: `/smart-issue-resolve #42 -cdxarl` → レビューモード: adversarial、系統: codex
 例: `/smart-issue-resolve #42 -cldarl` → レビューモード: adversarial、系統: claude
+例: `/smart-issue-resolve #42 -wt -cldrl` → worktree モードで着手し、claude 標準レビューループも実施
 
 `{レビューモード}` が `off` でも、手順 6 の後にセキュリティ影響を検出した場合は `adversarial` に自動昇格する（「レビューモードの確定」参照）。
 
@@ -111,6 +116,10 @@ smart-issue-plan が作成した計画があれば、実装前に参照する。
 
 現在のブランチ・未コミット変更・ローカルブランチ一覧を取得。
 
+**`{worktree}` = true の場合** — 手順 5 で新規作成する worktree に新しいブランチを切るため、現在の作業ツリーには一切手を加えない。未コミット変更があってもそのまま現在の作業ツリーに残ればよく、stash は不要（本手順の stash 判定・退避フローは `{worktree}` = false のときのみ適用する）。現在どのブランチにいるかも worktree 作成には影響しないため確認を省略してよい。
+
+**`{worktree}` = false の場合（既定）**:
+
 - **未コミット変更あり** → ユーザーに通知、続行なら `git stash push -m "smart-issue-resolve: <元ブランチ名> の退避"` で **メッセージ付き** stash する（手順 5 の分岐判定に使う）
 - **デフォルトブランチ以外にいる** → 別作業中の可能性をユーザーに確認
 
@@ -141,14 +150,28 @@ stash する場合は **元ブランチ名・変更内容の概要** をユー�
 - 同じ Issue 番号のブランチがローカル・リモートに **1 件** 既存 → チェックアウトか新規作成かユーザーに確認する
 - **複数件** 既存（マイルストーン分割等で `-m1` `-m2` に分かれている場合） → 一覧をユーザーに提示し、対象ブランチをチェックアウトするか新規作成するか選択させる
 
-### 5. ブランチ作成・チェックアウト
+### 5. ブランチ作成・チェックアウト（または worktree 作成）
 
-ユーザー承認後、デフォルトブランチを最新にしてから新規ブランチを作成する。デフォルトブランチは `git symbolic-ref refs/remotes/origin/HEAD` で取得する（`origin/main` / `origin/master` / `origin/develop` 等を自動判別）。取得できない場合はユーザーに確認する。
+ユーザー承認後、デフォルトブランチを最新にする（`git fetch` でリモート参照を更新する — worktree モードで `origin/<デフォルトブランチ>` から直接分岐する場合、これを省くと古い参照のままブランチを作成してしまう）。デフォルトブランチは `git symbolic-ref refs/remotes/origin/HEAD` で取得する（`origin/main` / `origin/master` / `origin/develop` 等を自動判別）。取得できない場合はユーザーに確認する。
 
-stash の復元は手順 3 で記録したフラグに基づいて分岐する:
+**`{worktree}` = false の場合（既定）** — 現在の作業ツリーでブランチを作成・チェックアウトする:
+
+デフォルトブランチを最新にしてから新規ブランチを作成する。stash の復元は手順 3 で記録したフラグに基づいて分岐する:
 
 - **現 Issue の作業の続き** → 新ブランチ上で `git stash pop`
 - **無関係な作業の退避** → 新ブランチ上では pop せず stash に残す。「元のブランチに戻ってから `git stash list` / `git stash pop` で復元してください」と案内する
+
+**`{worktree}` = true の場合** — 現在の作業ツリーには触れず、別ディレクトリの git worktree にブランチを作成する。セッションが既に別の worktree にいる場合、カレントディレクトリからの相対パスで作業すると worktree の中に入れ子で worktree を作ってしまう（そのうえ `EnterWorktree` の「切り替え先は同一リポジトリの `.claude/worktrees/` 配下」という制約も満たせなくなる）。そのため必ず**メイン worktree の絶対パスを起点**にする:
+
+1. **メインルートの特定** — `git worktree list --porcelain | head -1 | cut -d' ' -f2-` でメイン worktree の絶対パス（`{メインルート}`）を取得する（porcelain 出力の先頭エントリは常にメイン worktree）
+2. **除外設定の確認** — `git -C "{メインルート}" check-ignore -q .claude/worktrees/`（**末尾のスラッシュ必須** — 無いとディレクトリ未作成の間は誤判定する）が失敗する（＝まだ無視されていない）場合、`$(git rev-parse --git-common-dir)/info/exclude` に `.claude/worktrees/` を追記する（`git rev-parse --git-common-dir` は main tree・linked worktree のどちらから実行しても常に共有 `.git` を指す絶対パス〔または main tree からの相対 `.git`〕を返す。linked worktree では `.git` はファイルであり直接パスを組み立てると失敗するため必須。リポジトリの追跡対象 `.gitignore` は変更しない・ローカル限定の除外）
+3. **worktree パスの決定** — `{メインルート}/.claude/worktrees/<ブランチ名>` を使う。既に存在する場合（前回の中断等）は再利用するか削除して作り直すかユーザーに確認する
+4. **worktree の作成**:
+   - **新規ブランチの場合** → `git worktree add -b <ブランチ名> "{メインルート}/.claude/worktrees/<ブランチ名>" origin/<デフォルトブランチ>` を実行する
+   - **既存ブランチをチェックアウトする場合** → `git worktree add "{メインルート}/.claude/worktrees/<ブランチ名>" <ブランチ名>` を実行する。そのブランチが既に現在の作業ツリー（または他の worktree）でチェックアウト中だと git がエラーを返す（`fatal: '<ブランチ名>' is already used by worktree at '<パス>'`）— その場合は「既に別の作業ツリーでチェックアウト中のため worktree 化できません。`-wt` を外すか、そちらの作業ツリー側で作業してください」とユーザーに伝えて終了する
+5. **セッションの切り替え** — `EnterWorktree({ path: "{メインルート}/.claude/worktrees/<ブランチ名>" })` を呼ぶ（`name` ではなく `path` を使う — 常に既存パスへの切り替えとして扱うことで、セッションが既に別の worktree にいる場合でも一様に動作する）。以降の手順（context.md 作成・Workflow 起動・レビューループ・コミット・PR）はすべてこの worktree 内で実行される
+6. 手順 3 で未コミット変更を検出していても、stash・pop は行わない（元の作業ツリーにそのまま残る）
+7. **EnterWorktree ツールが利用できない環境**（Claude Code 以外のホスト）では `{worktree}` を無視し、`{worktree}` = false と同じ手順にフォールグレードする。フォールグレードした旨をユーザーに伝える
 
 ### 6. 作業の実行（オーケストレーション）
 
@@ -159,7 +182,7 @@ stash の復元は手順 3 で記録したフラグに基づいて分岐する:
    - リポジトリ内のコーディングルール集を Glob で探索する（`**/rules/*.md`・`**/guidelines/*.md`・`docs/` 配下の規約など）。Issue・変更予定ファイルのドメインに関連するものだけを Read する（例: `ddd-*` / `*architecture*` / `db-*` / `api-*` / `performance*` / `test-coverage*` / `security*`）
    - 参照した実装計画（手順 2）の「依拠した前提」が指す基準
    - 見つからなければ「なし」として進める（degradation）
-2. **作業ディレクトリの作成** — `mktemp -d "${TMPDIR:-/tmp}/sir-issue-<番号>.XXXXXX"` で `{作業Dir}` を作成する（OS の一時領域。スキル側で削除手順は持たない）。あわせて本スキルの [assets/gen-diff.sh](assets/gen-diff.sh)（Claude Code では `${CLAUDE_SKILL_DIR}/assets/gen-diff.sh` が実体のパスに展開される）を `{作業Dir}/gen-diff.sh` へコピーする（claude 系レビューループのレビュー正本 `diff.md` の生成に使う。開発者エージェントは `{作業Dir}` しか知らないため、スキル本体のパスに依存させない。コピーできない環境ではレビュー役が自前の git 取得にフォールバックする）
+2. **作業ディレクトリの作成** — `mktemp -d "${TMPDIR:-/tmp}/sir-issue-<番号>.XXXXXX"` で `{作業Dir}` を作成する（OS の一時領域。スキル側で削除手順は持たない。`{worktree}` = true でもコードの worktree〔`.claude/worktrees/<ブランチ名>`〕とは別物で、混同しない）。あわせて本スキルの [assets/gen-diff.sh](assets/gen-diff.sh)（Claude Code では `${CLAUDE_SKILL_DIR}/assets/gen-diff.sh` が実体のパスに展開される）を `{作業Dir}/gen-diff.sh` へコピーする（claude 系レビューループのレビュー正本 `diff.md` の生成に使う。開発者エージェントは `{作業Dir}` しか知らないため、スキル本体のパスに依存させない。コピーできない環境ではレビュー役が自前の git 取得にフォールバックする）
 3. **context.md の書き出し** — 雛形の書式で `{作業Dir}/context.md` を書く（Issue 要件・実装計画要約・`-p` 指示・ブランチ / diff 基準・テスト方針・プロジェクト固有基準）。テスト方針には関連スコープの実行コマンドを具体化して書く。テストが特定できない / フレームワークが不明な場合は、手動確認方針（再現手順・確認すべき画面や API レスポンス等）をユーザーに提示・合意してから書く
 4. **ゲート** — `{作業Dir}/context.md` が存在しない場合は Workflow を起動しない（作成に戻る）
 5. **実装 Workflow の起動** — 雛形 A（sir-implement）を起動する。Workflow の起動（雛形 A〜E 共通）では、起動直前に `TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M:%S'` を実測した開始日時を `startedAt` として `args` に含める（開始ログ表示用。グローバルルールの開始日時表示と同じ実測値を使い回してよい）。`needDesign` は「計画が無い、または計画の実装手順が具体ファイルに落ちていない」場合に true。内部フロー: 設計役（条件付き）→ 開発者 → 独立 QA（不合格なら開発者が修正、最大 2 回）→ 設計役の事後レビュー（設計整合・保守性・可用性）→ 開発者の採用判定・反映 → QA 再確認
@@ -196,6 +219,7 @@ stash の復元は手順 3 で記録したフラグに基づいて分岐する:
 - 実装した要件: <Issue の受け入れ基準に対する対応内容を箇条書きで>
 - 動作確認: <開発者エージェントのテスト結果と、独立 QA が実行した検証（コマンドと結果）>
 - 設計整合レビュー: <設計役の指摘数と採用 / 不採用（不採用理由）。指摘 0 件ならその旨>
+- 作業ディレクトリ: <worktree のパス>
 
 次のステップ:
 1. コミット → `/smart-commit`
@@ -203,6 +227,8 @@ stash の復元は手順 3 で記録したフラグに基づいて分岐する:
 ```
 
 `{作業Dir}/impl-notes.md` に開発者エージェントが記録した「自分で判断した事項」があれば、ユーザーが把握すべき決定事項として言及する。
+
+「作業ディレクトリ」の行は `{worktree}` = true のときだけテンプレートに含める（false のときは行ごと省く）。`{worktree}` = true の場合、セッションは worktree 内に留まったまま完了する（`ExitWorktree` はユーザーから明示的な指示があるまで本スキルからは呼び出さない）。完了案内には worktree のパスに加えて、元の作業ツリーへ戻るには `ExitWorktree({ action: "keep" })` を使うか新規セッションを開始する旨を明記する。worktree・ブランチの削除（マージ後のクリーンアップ）は `/smart-git-sync` に任せる。
 
 degraded 実装（Workflow 不能）の場合は「独立 QA・設計整合レビューは未実施（Workflow 不能）」とサマリに明記し、動作確認欄にはメインセッションが実行したテスト / 手動確認の結果を書く（実行していない検証を記載しない）。
 
@@ -298,7 +324,7 @@ Breaker（独立 Sonnet エージェント）× Codex=Judge の二者構造で�
    - claude 敵対・収束時: `🤖 Claude 敵対的レビュー済み（Breaker×Judge=独立 Opus, N ラウンド, 最終ラウンド採用指摘 0 件）`
    - 打ち切り時: `🤖 <Codex|Claude> レビュー実施（<standard|adversarial>, N ラウンド, 未収束で打ち切り）`
    - 記載先: 標準構成なら `## 備考`、簡易構成なら `## レビュアー向け補足`
-4. **完了報告** — PR URL・変更サマリ・ループ記録（系統, モード, ラウンド数, 各ラウンドの指摘数 / 採用数 / 不採用理由）・最終 QA 結果を提示して終了
+4. **完了報告** — PR URL・変更サマリ・ループ記録（系統, モード, ラウンド数, 各ラウンドの指摘数 / 採用数 / 不採用理由）・最終 QA 結果を提示して終了。`{worktree}` = true の場合は worktree のパスも併記し、元の作業ツリーへ戻るには `ExitWorktree({ action: "keep" })` か新規セッション開始が必要な旨を伝える（PR マージ後の worktree・ブランチ削除は `/smart-git-sync` に任せる）
 
 behind 時のマージ確認・競合対応は履歴に影響するため、自動オプトインの対象外とし通常どおりユーザーに確認する。ユーザーが手動で `/smart-commit` `/smart-pr` を使う経路は従来どおり有効（自動実行時のみ git/gh 直呼びに切り替える）。
 
@@ -350,3 +376,4 @@ behind 時のマージ確認・競合対応は履歴に影響するため、自�
 - コミット・push を行うのはオーケストレーターの「収束後のコミット・PR 作成」経路のみ。各エージェント（設計役・開発者・QA・レビュワー・Breaker・Judge・監査役）にはコミット・push をさせない（プロンプトに内蔵済み）
 - Issue と関係のない変更を混ぜない（混ざった場合は smart-commit 側で分割する旨を案内する）
 - 反例テスト（`.breaker-probe.` 命名）を最終的な変更セットに残さない（採用した欠陥の回帰テストは正規の命名・配置に変換する）
+- `{worktree}` = true の場合、実装は元の作業ツリーとは別の git worktree（`.claude/worktrees/<ブランチ名>`）で完結する。`ExitWorktree` は本スキルからは呼び出さない（ユーザーが明示的に指示したときのみ実行するツールのため — 完了後もセッションは worktree に留まる）。worktree・ブランチの削除（マージ後のクリーンアップ）は `/smart-git-sync` に任せる


### PR DESCRIPTION
## 概要

smart-issue-resolve に `-wt`/`--worktree` オプションを追加する。指定時は現在の作業ツリーを変更せず、git worktree（Claude Code の EnterWorktree ツール）に分離した作業ディレクトリでブランチ作成から実装まで完結できるようにする。

- 実装ノート: docs/implementation-notes/2026-08-01-sir-worktree-option.md

## 実装内容

| ファイル | 役割 |
|---|---|
| `skills/smart-issue-resolve/SKILL.md` | 引数解析への `-wt`/`--worktree` 追加、手順3（stash判定スキップ）・手順5（worktree作成分岐）、完了案内・PR作成手順への worktree 案内追記 |
| `skills/smart-issue-resolve/README.md` | 使い方・オプション表・フロー・関連スキル・前提条件を同期 |
| `docs/implementation-notes/2026-08-01-sir-worktree-option.md` | 設計判断・トレードオフ・実機検証記録 |

```mermaid
flowchart TD
    A["-wt / --worktree 指定"] --> B["git fetch でリモート参照を更新"]
    B --> C["git worktree list --porcelain でメインworktree絶対パスを取得"]
    C --> D{"'.claude/worktrees/' は\n既に無視設定済みか"}
    D -- No --> E["git-common-dir の info/exclude に追記"]
    D -- Yes --> F
    E --> F["メインルート/.claude/worktrees/&lt;ブランチ名&gt; を決定"]
    F --> G["git worktree add でブランチ作成\n（新規 or 既存）"]
    G --> H["EnterWorktree({ path }) でセッション切替"]
    H --> I["以降の手順は worktree 内で完結"]
```

## 設計判断（要点）

### 採用した方針

| 観点 | 採用案 | 理由 |
|---|---|---|
| `EnterWorktree` の呼び出し方法 | 常に `path` 指定（`name` は使わない） | `worktree.baseRef` 設定に依存せず、常に `origin/<デフォルトブランチ>` から明示的に分岐できるため |
| worktree パスの起点 | メイン worktree の絶対パス（`git worktree list --porcelain` で取得） | セッションが既に別の linked worktree にいる場合の入れ子 worktree 化・`.git/info/exclude` 書き込み失敗を回避するため |
| worktree・ブランチの削除 | 本スキルでは実装せず `/smart-git-sync` に委譲 | 直近（2026-07-31）実装済みの worktree クリーンアップ機能との重複実装を避けるため |
| セッション終了時の `ExitWorktree` | 呼ばない（worktree に留まる） | ツール自身の「ユーザーの明示指示時のみ」という制約に従うため |

### 未対応（follow-up）

| 項目 | 理由 | 対応先 |
|---|---|---|
| `smart-spec-to-pr` のレビューループフラグ転送語彙への `-wt` 追加 | CLAUDE.md の同期ルールはレビューループフラグ名限定でスコープ外。ユーザー依頼も本スキル単体だった | 必要になれば別 Issue |

## レビュースコープ

**重点レビュー**: 手順5の worktree 分岐（`git worktree add` のパス構築・`EnterWorktree` の呼び出しタイミング・linked worktree からの実行時の絶対パス解決）

**対象外**: なし

## 動作確認

### 受入条件（期待結果）

| # | 受け入れ基準 | 検証 |
|---|---|---|
| 1 | `-wt`/`--worktree` 指定時、現在の作業ツリーを変更せず別 worktree でブランチ作成〜実装が完結する | 使い捨て worktree で `EnterWorktree` 実行 → 1 エージェントの Workflow の `pwd`/`git branch --show-current` がオーケストレーターと一致することを確認（cwd 継承の実証） |
| 2 | worktree ディレクトリがメイン作業ツリーの `git status` を汚染しない | 素の git リポジトリで手動 `git worktree add` を実行し `.git/info/exclude` への追記で解消することを実機確認 |
| 3 | セッションが既に linked worktree にいる場合でも、メイン worktree 配下に正しく新規 worktree を作成できる | linked worktree 内から `git worktree list --porcelain` でメインルートを特定し、そこを起点に新規 worktree 作成が正しく行われることを確認 |
| 4 | ブランチ名にスラッシュを含む場合（実際の命名規則どおり）でも worktree が正常作成される | `git worktree add -b feature/issue-1-x ...` を実機実行し中間ディレクトリが自動作成されることを確認 |

### 確認手順

```bash
# 検証はすべて使い捨てのworktree・一時gitリポジトリで実施（詳細は実装ノート参照）
git worktree add -b feature/issue-1-x .claude/worktrees/feature/issue-1-x HEAD
git worktree list
```

## 備考

コード（実装言語）の変更を含まないため lint / test 実行対象はなし（SKILL.md / README.md の Markdown 変更のみ）。設計判断の詳細・実機検証ログは実装ノートを参照。